### PR TITLE
fixed path handling on Windows

### DIFF
--- a/test/render_svg_test.dart
+++ b/test/render_svg_test.dart
@@ -8,8 +8,9 @@ import 'package:test/test.dart';
 import '../tool/gen_golden.dart' as golden;
 
 Iterable<File> getGoldenFileNames() sync* {
-  final Directory dir = new Directory(join(dirname(Platform.script.path),
-      dirname(Platform.script.path).endsWith('test') ? '..' : '', 'golden'));
+  final String root = dirname(Platform.script.toFilePath());
+  final Directory dir = new Directory(join(root,
+      root.endsWith('test') ? '..' : '', 'golden'));
   for (FileSystemEntity fe in dir.listSync(recursive: true)) {
     if (fe is File && fe.path.toLowerCase().endsWith('.png')) {
       yield fe;


### PR DESCRIPTION
Fixed the broken Windows path issue in the unit tests. You have to use `Platform.script.toFilePath()` instead of `Platform.script.path` because the latter is the path part of a Uri, but we want an actual file system path.

Now only the PNG comparison and the SvgPicture.network test still fail.