### PR TITLE
color percentages can be floats and there can be whitespace everywhere

### DIFF
--- a/lib/src/svg/colors.dart
+++ b/lib/src/svg/colors.dart
@@ -32,20 +32,18 @@ Color parseColor(String colorString) {
   }
 
   // handle rgb() colors e.g. rgb(255, 255, 255)
-  if (colorString.startsWith('rgb')) {
+  if (colorString.toLowerCase().startsWith('rgb')) {
     final List<int> rgb = colorString
         .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
         .split(',')
-        .map(
-      (String rawColor) {
-        if (rawColor.endsWith('%')) {
-          final int percentage =
-              int.parse(rawColor.substring(0, rawColor.length - 1));
-          return (percentage * 2.55).round();
-        }
-        return int.parse(rawColor);
-      },
-    ).toList();
+        .map((String rawColor) {
+      rawColor = rawColor.trim();
+      if (rawColor.endsWith('%')) {
+        rawColor = rawColor.substring(0, rawColor.length - 1);
+        return (double.parse(rawColor) * 2.55).round();
+      }
+      return int.parse(rawColor);
+    }).toList();
 
     // rgba() isn't really in the spec, but Firefox supported it at one point so why not.
     final int a = rgb.length > 3 ? rgb[3] : 255;

--- a/test/colors_svg_test.dart
+++ b/test/colors_svg_test.dart
@@ -11,6 +11,8 @@ void main() {
     expect(parseColor('white'), white);
     expect(parseColor('rgb(255, 255, 255)'), white);
     expect(parseColor('rgb(100%, 100%, 100%)'), white);
+    expect(parseColor('RGB(  100%   ,   100.0% ,  99.9999% )'), white);
+    expect(parseColor('rGb( .0%,0.0%,.0000001% )'), black);
     expect(parseColor('rgba(255,255, 255, 255)'), white);
     expect(parseColor('#DDFFFFFF'), const Color(0xDDFFFFFF));
     expect(parseColor(''), black);


### PR DESCRIPTION
Tried following the spec more closely.