### PR TITLE
Use the headers to get the file

### DIFF
--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -474,6 +474,9 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
     assert(key == this);
     final Uri uri = Uri.base.resolve(url);
     final HttpClientRequest request = await _httpClient.getUrl(uri);
+	headers.forEach((key, value) {
+		request.headers.add(key, value);
+	});
     final HttpClientResponse response = await request.close();
 
     if (response.statusCode != HttpStatus.OK) {


### PR DESCRIPTION
Headers are capture, but not use to make the call, this makes the call that need specific headers not to perform properly.

In my tests, headers are needed for authorization, so the image is not recovered, just a redirected page to login, with the expected parse error as consecuence