### PR TITLE
Run "flutter format" and "analyze" and clean up deprecated warning

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -83,7 +83,8 @@ class _MyHomePageState extends State<MyHomePage> {
     super.initState();
     _dimension = 250.0;
 
-    _painters.add(new SvgPicture.string('<svg viewBox="0 0 120 120"><path d="M20,30 Q40,5 60,30 T100,30" stroke="red" fill="none"/></svg>'));
+    _painters.add(new SvgPicture.string(
+        '<svg viewBox="0 0 120 120"><path d="M20,30 Q40,5 60,30 T100,30" stroke="red" fill="none"/></svg>'));
 
     for (String assetName in assetNames) {
       _painters.add(

--- a/lib/src/avd/xml_parsers.dart
+++ b/lib/src/avd/xml_parsers.dart
@@ -24,8 +24,8 @@ Rect parseViewBox(XmlElement el) {
 }
 
 Matrix4 parseTransform(XmlElement el) {
-  final double rotation = double.parse(
-      getAttribute(el, 'rotation', def: '0', namespace: androidNS));
+  final double rotation = double
+      .parse(getAttribute(el, 'rotation', def: '0', namespace: androidNS));
   final double pivotX =
       double.parse(getAttribute(el, 'pivotX', def: '0', namespace: androidNS));
   final double pivotY =
@@ -34,10 +34,10 @@ Matrix4 parseTransform(XmlElement el) {
       double.parse(getAttribute(el, 'scaleX', def: '1', namespace: androidNS));
   final double scaleY =
       double.parse(getAttribute(el, 'scaleY', def: '1', namespace: androidNS));
-  final double translateX = double.parse(
-      getAttribute(el, 'translateX', def: '0', namespace: androidNS));
-  final double translateY = double.parse(
-      getAttribute(el, 'translateY', def: '0', namespace: androidNS));
+  final double translateX = double
+      .parse(getAttribute(el, 'translateX', def: '0', namespace: androidNS));
+  final double translateY = double
+      .parse(getAttribute(el, 'translateY', def: '0', namespace: androidNS));
 
   return new Matrix4.identity()
     ..translate(pivotX, pivotY)
@@ -54,10 +54,10 @@ Paint parseStroke(XmlElement el, Rect bounds) {
   }
   return new Paint()
     ..style = PaintingStyle.stroke
-    ..color = parseColor(rawStroke).withOpacity(double.parse(
-        getAttribute(el, 'strokeAlpha', def: '1', namespace: androidNS)))
-    ..strokeWidth = double.parse(
-        getAttribute(el, 'strokeWidth', def: '0', namespace: androidNS))
+    ..color = parseColor(rawStroke).withOpacity(double
+        .parse(getAttribute(el, 'strokeAlpha', def: '1', namespace: androidNS)))
+    ..strokeWidth = double
+        .parse(getAttribute(el, 'strokeWidth', def: '0', namespace: androidNS))
     ..strokeCap = parseStrokeCap(el)
     ..strokeJoin = parseStrokeJoin(el)
     ..strokeMiterLimit = parseMiterLimit(el);

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -481,7 +481,7 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
     }
     final HttpClientResponse response = await request.close();
 
-    if (response.statusCode != HttpStatus.OK) {
+    if (response.statusCode != HttpStatus.ok) {
       throw new HttpException('Could not get network asset', uri: uri);
     }
     final Uint8List bytes = await consolidateHttpClientResponseBytes(response);

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -481,7 +481,7 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
     }
     final HttpClientResponse response = await request.close();
 
-    if (response.statusCode != HttpStatus.ok) {
+    if (response.statusCode != HttpStatus.OK) {
       throw new HttpException('Could not get network asset', uri: uri);
     }
     final Uint8List bytes = await consolidateHttpClientResponseBytes(response);


### PR DESCRIPTION
I have two PRs in the queue for this repo and wanted to first bring it up-to-date according to the instructions in the `CONTRIBUTING.md` file.

The deprecated warning was:

```
Analyzing flutter_svg...                                         

   info • 'OK' is deprecated and shouldn't be used • lib/src/picture_provider.dart:484:43

1 issue found. (ran in 1.3s)
```

So I switched it to `HttpStatus.ok` because I found that change here:
https://dart-review.googlesource.com/c/sdk/+/61300/2/pkg/analysis_server/tool/instrumentation/server.dart