### PR TITLE
Skip <title> tag if in the SVG.

### DIFF
--- a/lib/src/svg_parser.dart
+++ b/lib/src/svg_parser.dart
@@ -101,6 +101,9 @@ void _unhandledElement(XmlElement el, String key) {
       library: 'SVG',
       context: 'in parseSvgElement',
     ));
+  } else if (el.name.local == 'title') {
+    print("WARNING: flutter_svg doesn't support the title tag.");
+    return;
   }
   assert(() {
     if (_unhandledElements.add(el.name.local)) {


### PR DESCRIPTION
Rendering shouldn't fail when a title tag is provided as they are part
of the SVG spec:
https://www.w3.org/TR/SVG2/struct.html#DescriptionAndTitleElements

This skips the title tag and warns of it not being used.

Signed-off-by: Nick Campbell <nicholas.j.campbell@gmail.com>