### PR TITLE
Fix CI by changing linter options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -110,7 +110,7 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    # - prefer_collection_literals # it's triggering on Set literals which are not ready https://github.com/dart-lang/linter/issues/1411
+    - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_const_constructors_in_immutables

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -110,7 +110,7 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_collection_literals
+    # - prefer_collection_literals # it's triggering on Set literals which are not ready https://github.com/dart-lang/linter/issues/1411
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_const_constructors_in_immutables
@@ -141,7 +141,6 @@ linter:
     - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
-    - super_goes_last
     - public_member_api_docs
     - test_types_in_equals
     - throw_in_finally

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -16,6 +16,8 @@ import 'colors.dart';
 import 'parsers.dart';
 import 'xml_parsers.dart';
 
+// TODO(dart-lang/issues#1411): Fix once set literals are released.
+// ignore: prefer_collection_literals
 final Set<String> _unhandledElements = Set<String>();
 
 typedef _ParseFunc = Future<void> Function(SvgParserState parserState);


### PR DESCRIPTION
Remove a deprecated one and comment out one that is triggering on new
language features.