### PR TITLE
Add missing comma in code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ final Widget svg = new SvgPicture.asset(
 
 final Widget networkSvg = new SvgPicture.network(
   'https://site-that-takes-a-while.com/image.svg',
-  semanticsLabel: 'A shark?!'
+  semanticsLabel: 'A shark?!',
   placeholderBuilder: (BuildContext context) => new Container(
       padding: const EdgeInsets.all(30.0),
       child: const CircularProgressIndicator()),


### PR DESCRIPTION
Thanks for the package! :) I believe the example requires the comma for it to be runnable code.

On another note, the flutter logo image is broken at https://pub.dartlang.org/packages/flutter_svg. I'm using Chrome but I suspect it has something to with the img `src` is referring to Github which doesn't seem to work for pub?

![image](https://user-images.githubusercontent.com/9021054/53272731-f5557400-36a6-11e9-96ec-392298e6c489.png)
