### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ of something that's broken.
 - SMIL animations. That just seems crazy. I think it'll be possible to animate
   the SVG but probably in a more Flutter driven way.
 - Interactivity/events in SVG.
-- Full (any?) CSS support - preprocess your SVGs (perhaps with [usvg](https://github.com/RazrFalcon/resvg/tree/master/usvg) to get
-  rid of all CSS?).
+- Full (any?) CSS support - preprocess your SVGs (perhaps with [usvg](https://github.com/RazrFalcon/resvg/tree/master/usvg) or [scour](https://github.com/scour-project/scour) to get rid of all CSS?).
 - Scripting in SVGs
 - Foreign elements
 - Rendering properties/hints


### PR DESCRIPTION
Added an alternative SVG preprocessor to usvg : scour. It is used by a lot of people (including Inkscape) and is a lot easier to use : `scour -i input.svg -o output.svg`.