### PR TITLE
Check transform before calling into it.

### DIFF
--- a/lib/src/svg/xml_parsers.dart
+++ b/lib/src/svg/xml_parsers.dart
@@ -346,16 +346,18 @@ DrawableStyle parseStyle(
     final Matrix4 transform = parseTransform(
       getAttribute(attributes, 'transform'),
     );
-    if (multiplyTransformByParent && parentStyle?.transform != null) {
-      if (transform == null) {
-        rawTransform = parentStyle.transform;
+    if (transform != null) {
+      if (multiplyTransformByParent && parentStyle?.transform != null) {
+        if (transform == null) {
+          rawTransform = parentStyle.transform;
+        } else {
+          rawTransform = Matrix4.fromFloat64List(parentStyle.transform)
+              .multiplied(transform)
+              .storage;
+        }
       } else {
-        rawTransform = Matrix4.fromFloat64List(parentStyle.transform)
-            .multiplied(transform)
-            .storage;
+        rawTransform = transform.storage;
       }
-    } else {
-      rawTransform = transform.storage;
     }
   }
   return DrawableStyle.mergeAndBlend(


### PR DESCRIPTION
There isn't an explicit check to see if the transform was null before calling into it. This was causing a `NoSuchMethodError` trying to call `transform.storage`. Adding the check here stopped that error from occurring.

Signed-off-by: Nick Campbell <nicholas.j.campbell@gmail.com>