### PR TITLE
Causes error when widget disposed

### DIFF
--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -620,9 +620,11 @@ class _SvgPictureState extends State<SvgPicture> {
   }
 
   void _handleImageChanged(PictureInfo imageInfo, bool synchronousCall) {
-    setState(() {
-      _picture = imageInfo;
-    });
+    if (mounted) {
+      setState(() {
+        _picture = imageInfo;
+      });
+    }
   }
 
   // Update _pictureStream to newStream, and moves the stream listener


### PR DESCRIPTION
I have scroll list, sometimes I scroll so fast that the Widget gets disposed by flutter. I undoubtedly get an error here since we are attempting to setState on a widget that is not on the screen anymore.

See error below:

> flutter: ══╡ EXCEPTION CAUGHT BY SVG ╞═══════════════════════════════════════════════════════════════════════
> flutter: The following assertion was thrown by a picture listener:
> flutter: setState() called after dispose(): _SvgPictureState#e68e1(lifecycle state: defunct, not mounted,
> flutter: stream: PictureStream#452fe(OneFramePictureStreamCompleter#f936a, Instance of 'PictureInfo', 1
> flutter: listener))
> flutter: This error happens if you call setState() on a State object for a widget that no longer appears in
> flutter: the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error
> flutter: can occur when code calls setState() from a timer or an animation callback. The preferred solution
> flutter: is to cancel the timer or stop listening to the animation in the dispose() callback. Another
> flutter: solution is to check the "mounted" property of this object before calling setState() to ensure the
> flutter: object is still in the tree.
> flutter: This error might indicate a memory leak if setState() is being called because another object is
> flutter: retaining a reference to this State object after it has been removed from the tree. To avoid memory
> flutter: leaks, consider breaking the reference to this object during dispose().
> flutter:
> flutter: When the exception was thrown, this was the stack:
> flutter: # 0      State.setState.<anonymous closure> 
> package:flutter/…/widgets/framework.dart:1095
> flutter: # 1      State.setState 
> package:flutter/…/widgets/framework.dart:1121
> flutter: # 2      _SvgPictureState._handleImageChanged 
> package:flutter_svg/svg.dart:623