### PR TITLE
Add a delay by zero to make parsing async

### DIFF
--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -678,6 +678,8 @@ class SvgParserState {
   /// Drive the [XmlTextReader] to EOF and produce a [DrawableRoot].
   Future<DrawableRoot> parse() async {
     for (XmlEvent event in _readSubtree()) {
+      // Make sure the main thread is not completely blocked
+      await Future<void>.delayed(Duration.zero);
       if (event is XmlStartElementEvent) {
         if (startElement(event)) {
           continue;


### PR DESCRIPTION
Parsing in the current version turns out to be fully synchronous and needs to be done on the main thread (it gives an exception when running in an isolate that a native method is not available).
So to fix this I added an `await Future.delayed(Duration.zero);` which makes sure that the parsing is split up into small pieces that are computed async and don't block the main thread completely.