### PR TITLE
add support for hsl, hsla and transparent fill value

### DIFF
--- a/lib/src/svg/colors.dart
+++ b/lib/src/svg/colors.dart
@@ -52,28 +52,27 @@ Color parseColor(String colorString) {
 
   // Conversion code from: https://github.com/MichaelFenwick/Color, thanks :)
   if (colorString.toLowerCase().startsWith('hsl')) {
-    List<num> rgb = <num>[0, 0 , 0];
     final List<int> values = colorString
         .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
         .split(',')
         .map((String rawColor) {
-          rawColor = rawColor.trim();
-          
-          if (rawColor.endsWith('%')) {
-            rawColor = rawColor.substring(0, rawColor.length - 1);
-          }
+      rawColor = rawColor.trim();
 
-          if (rawColor.contains('.')) {
-            return (parseDouble(rawColor) * 2.55).round();
-          }
+      if (rawColor.endsWith('%')) {
+        rawColor = rawColor.substring(0, rawColor.length - 1);
+      }
 
-          return int.parse(rawColor);
-        }).toList();
+      if (rawColor.contains('.')) {
+        return (parseDouble(rawColor) * 2.55).round();
+      }
 
-    final num hue = values[0] / 360 % 1;
-    final num saturation = values[1] / 100;
-    final num luminance = values[2] / 100;
-    final num alpha = values.length > 3 ? values[3] : 255;
+      return int.parse(rawColor);
+    }).toList();
+    final double hue = values[0] / 360 % 1;
+    final double saturation = values[1] / 100;
+    final double luminance = values[2] / 100;
+    final int alpha = values.length > 3 ? values[3] : 255;
+    List<double> rgb = <double>[0, 0, 0];
 
     if (hue < 1 / 6) {
       rgb[0] = 1;
@@ -95,17 +94,21 @@ Color parseColor(String colorString) {
       rgb[2] = 6 - hue * 6;
     }
 
-    rgb = rgb.map((num val) => val + (1 - saturation) * (0.5 - val)).toList();
+    rgb =
+        rgb.map((double val) => val + (1 - saturation) * (0.5 - val)).toList();
 
     if (luminance < 0.5) {
-      rgb = rgb.map((num val) => luminance * 2 * val).toList();
+      rgb = rgb.map((double val) => luminance * 2 * val).toList();
     } else {
-      rgb = rgb.map((num val) => luminance * 2 * (1 - val) + 2 * val - 1).toList();
+      rgb = rgb
+          .map((double val) => luminance * 2 * (1 - val) + 2 * val - 1)
+          .toList();
     }
 
-    rgb = rgb.map((num val) => (val * 255).round()).toList();
+    rgb = rgb.map((double val) => val * 255).toList();
 
-    return Color.fromARGB(alpha, rgb[0], rgb[1], rgb[2]);
+    return Color.fromARGB(
+        alpha, rgb[0].round(), rgb[1].round(), rgb[2].round());
   }
 
   // handle rgb() colors e.g. rgb(255, 255, 255)
@@ -114,13 +117,13 @@ Color parseColor(String colorString) {
         .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
         .split(',')
         .map((String rawColor) {
-          rawColor = rawColor.trim();
-          if (rawColor.endsWith('%')) {
-            rawColor = rawColor.substring(0, rawColor.length - 1);
-            return (parseDouble(rawColor) * 2.55).round();
-          }
-          return int.parse(rawColor);
-        }).toList();
+      rawColor = rawColor.trim();
+      if (rawColor.endsWith('%')) {
+        rawColor = rawColor.substring(0, rawColor.length - 1);
+        return (parseDouble(rawColor) * 2.55).round();
+      }
+      return int.parse(rawColor);
+    }).toList();
 
     // rgba() isn't really in the spec, but Firefox supported it at one point so why not.
     final int a = rgb.length > 3 ? rgb[3] : 255;

--- a/lib/src/svg/colors.dart
+++ b/lib/src/svg/colors.dart
@@ -52,7 +52,7 @@ Color parseColor(String colorString) {
 
   // Conversion code from: https://github.com/MichaelFenwick/Color, thanks :)
   if (colorString.toLowerCase().startsWith('hsl')) {
-    List<num> rgb = [0, 0 , 0];
+    List<num> rgb = <num>[0, 0 , 0];
     final List<int> values = colorString
         .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
         .split(',')

--- a/test/colors_svg_test.dart
+++ b/test/colors_svg_test.dart
@@ -21,6 +21,9 @@ void main() {
     expect(parseColor('none'), null);
     expect(parseColor('hsl(0,0%,0%)'), const Color(0xFF000000));
     expect(parseColor('hsl(0,0%,100%)'), const Color(0xFFFFFFFF));
+    expect(parseColor('hsl(136,47%,79%)'), const Color(0xFFB0E3BE));
+    expect(parseColor('hsl(136,80%,9%)'), const Color(0xFF05290E));
+    expect(parseColor('hsl(135,100%,50%)'), const Color(0xFF00FF40));
     expect(parseColor('hsl(136,54%,43%)'), const Color(0xFF32A952));
     expect(parseColor('hsla(0,0%,100%, 0.0)'), const Color(0x00FFFFFF));
     expect(() => parseColor('invalid name'), throwsStateError);

--- a/test/colors_svg_test.dart
+++ b/test/colors_svg_test.dart
@@ -23,8 +23,10 @@ void main() {
     expect(parseColor('hsl(0,0%,100%)'), const Color(0xFFFFFFFF));
     expect(parseColor('hsl(136,47%,79%)'), const Color(0xFFB0E3BE));
     expect(parseColor('hsl(136,80%,9%)'), const Color(0xFF05290E));
-    expect(parseColor('hsl(135,100%,50%)'), const Color(0xFF00FF40));
-    expect(parseColor('hsl(136,54%,43%)'), const Color(0xFF32A952));
+    expect(parseColor('hsl(17,55%,29%)'), const Color(0xFF733821));
+    expect(parseColor('hsl(78,55%,29%)'), const Color(0xFF5A7321));
+    expect(parseColor('hsl(192,55%,29%)'), const Color(0xFF216273));
+    expect(parseColor('hsl(297,55%,29%)'), const Color(0xFF6F2173));
     expect(parseColor('hsla(0,0%,100%, 0.0)'), const Color(0x00FFFFFF));
     expect(() => parseColor('invalid name'), throwsStateError);
   });

--- a/test/colors_svg_test.dart
+++ b/test/colors_svg_test.dart
@@ -17,7 +17,12 @@ void main() {
     expect(parseColor('rgba(0,0, 0, 1.0)'), const Color(0xFF000000));
     expect(parseColor('#DDFFFFFF'), const Color(0xDDFFFFFF));
     expect(parseColor(''), black);
+    expect(parseColor('transparent'), const Color(0x00FFFFFF));
     expect(parseColor('none'), null);
+    expect(parseColor('hsl(0,0%,0%)'), const Color(0xFF000000));
+    expect(parseColor('hsl(0,0%,100%)'), const Color(0xFFFFFFFF));
+    expect(parseColor('hsl(136,54%,43%)'), const Color(0xFF32A952));
+    expect(parseColor('hsla(0,0%,100%, 0.0)'), const Color(0x00FFFFFF));
     expect(() => parseColor('invalid name'), throwsStateError);
   });
 }


### PR DESCRIPTION
Thanks for an excellent library!

I am using [FramerX](https://www.framer.com/) to create SVGs. Sometimes it uses `fill="transparent"`and `fill="hsl(0,0%,0%)"` etc. I have been manually converting this, though thought it would be nice to just get it out of the box as there are probably other scenarios where this is an issue as well.

The HSL(A) conversion logic is taken from: https://github.com/MichaelFenwick/Color

So big shoutout to @MichaelFenwick for also creating an excellent package ❤️ 