### PR TITLE
Only fix image size on one dimension

### DIFF
--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -709,8 +709,8 @@ class _SvgPictureState extends State<SvgPicture> {
       double width = widget.width;
       double height = widget.height;
       if (width == null && height == null) {
-        width = viewport.width;
-        height = viewport.height;
+        width = viewport.width > viewport.height ? viewport.width : null;
+        height = viewport.height > viewport.width ? viewport.height : null;
       } else if (height != null) {
         width = height / viewport.height * viewport.width;
       } else if (width != null) {

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -704,33 +704,16 @@ class _SvgPictureState extends State<SvgPicture> {
     }
 
     if (_picture != null) {
-      final Rect viewport = Offset.zero & _picture.viewport.size;
-
-      double width = widget.width;
-      double height = widget.height;
-      if (width == null && height == null) {
-        width = viewport.width > viewport.height ? viewport.width : null;
-        height = viewport.height > viewport.width ? viewport.height : null;
-      } else if (height != null) {
-        width = height / viewport.height * viewport.width;
-      } else if (width != null) {
-        height = width / viewport.width * viewport.height;
-      }
-
       return _maybeWrapWithSemantics(
-        SizedBox(
-          width: width,
-          height: height,
-          child: FittedBox(
-            fit: widget.fit,
-            alignment: widget.alignment,
-            child: SizedBox.fromSize(
-              size: viewport.size,
-              child: RawPicture(
-                _picture,
-                matchTextDirection: widget.matchTextDirection,
-                allowDrawingOutsideViewBox: widget.allowDrawingOutsideViewBox,
-              ),
+        FittedBox(
+          fit: widget.fit,
+          alignment: widget.alignment,
+          child: SizedBox.fromSize(
+            size: _picture.viewport.size,
+            child: RawPicture(
+              _picture,
+              matchTextDirection: widget.matchTextDirection,
+              allowDrawingOutsideViewBox: widget.allowDrawingOutsideViewBox,
             ),
           ),
         ),


### PR DESCRIPTION
Fixes #227

This is intended to fix #227, but I may have missed something. The outer `SizedBox` was the culprit and in my opinion shouldn't be there. This PR removes it and my testing has shown it to work correctly now.