### PR TITLE
Strip all whitespace instead of only spaces from base64 encoded images.

### DIFF
--- a/example/assets/simple/image.svg
+++ b/example/assets/simple/image.svg
@@ -1,6 +1,8 @@
 <svg viewBox="0 0 50 50"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
-    <image xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNb yblA AAAHElEQVQI12P4//8/w3 8GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" height="20" width="20" transform="translate(1 1)"/>
+    <image xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA
+UAAAAFCAYAAACNb yblA AAAHElEQVQI12P4//8/w3 8GIAXDIBKE0DHxgljN
+BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" height="20" width="20" transform="translate(1 1)"/>
     <image xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="25" y="25" height="1" width="1"/>
 </svg>

--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -194,6 +194,8 @@ PathFillType parseRawFillRule(String rawFillRule) {
   return rawFillRule != 'evenodd' ? PathFillType.nonZero : PathFillType.evenOdd;
 }
 
+final RegExp _whitespacePattern = RegExp(r'\s');
+
 /// Resolves an image reference, potentially downloading it via HTTP.
 Future<Image> resolveImage(String href) async {
   if (href == null || href == '') {
@@ -214,8 +216,8 @@ Future<Image> resolveImage(String href) async {
 
   if (href.startsWith('data:')) {
     final int commaLocation = href.indexOf(',') + 1;
-    final Uint8List bytes =
-        base64.decode(href.substring(commaLocation).replaceAll(' ', ''));
+    final Uint8List bytes = base64.decode(
+        href.substring(commaLocation).replaceAll(_whitespacePattern, ''));
     return decodeImage(bytes);
   }
 


### PR DESCRIPTION
Adobe Illustrator splits base64 encoded raster images into multiple lines.
This fix strips all whitespace from base64 encoded images instead of only spaces.
Chromium ignores newlines and renders (parses) these images correctly.