### PR TITLE
Diagnosticable => DiagnosticableMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## 0.17.2
+
+- Bumped minimum Flutter version to 1.6.7 to pick up DiagnosticableMixin.
+
 ## 0.17.1
 
 - Fix for issue with `use` elements refering to groups or other `use` elements

--- a/lib/src/picture_stream.dart
+++ b/lib/src/picture_stream.dart
@@ -85,7 +85,7 @@ typedef PictureListener = Function(PictureInfo image, bool synchronousCall);
 ///
 ///  * [PictureProvider], which has an example that includes the use of an
 ///    [PictureStream] in a [Widget].
-class PictureStream extends Diagnosticable {
+class PictureStream with DiagnosticableMixin {
   /// Create an initially unbound image stream.
   ///
   /// Once an [PictureStreamCompleter] is available, call [setCompleter].
@@ -189,7 +189,7 @@ class PictureStream extends Diagnosticable {
 /// [PictureStreamListener] objects are rarely constructed directly. Generally, an
 /// [PictureProvider] subclass will return an [PictureStream] and automatically
 /// configure it with the right [PictureStreamCompleter] when possible.
-abstract class PictureStreamCompleter extends Diagnosticable {
+abstract class PictureStreamCompleter with DiagnosticableMixin {
   final List<_PictureListenerPair> _listeners = <_PictureListenerPair>[];
   PictureInfo _current;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 homepage: https://github.com/dnfield/flutter_svg
-version: 0.17.1
+version: 0.17.2
 
 dependencies:
   path_drawing: ^0.4.1
@@ -20,7 +20,7 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.5.9-pre.94 <2.0.0"
+  flutter: ">=1.6.7 <2.0.0"
 
 ## For developing features that require new functionality in engine:
 # dependency_overrides:


### PR DESCRIPTION
Converting these to DiagnosticableMixin, in preparation for eventually deprecating `Diagnosticable`.