### PR TITLE
Allow additional whitespace between transform commands.

### DIFF
--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -101,7 +101,7 @@ Matrix4 parseTransform(String transform) {
       _transformCommand.allMatches(transform).toList().reversed;
   Matrix4 result = Matrix4.identity();
   for (Match m in matches) {
-    final String command = m.group(1);
+    final String command = m.group(1).trim();
     final String params = m.group(2);
 
     final MatrixParser transformer = _matrixParsers[command];

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -56,7 +56,7 @@ void main() {
         ]));
 
     expect(parseTransform('rotate(20)\n\tscale(10)'),
-      Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
+        Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
   });
 
   test('FillRule tests', () {

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -54,6 +54,9 @@ void main() {
           0.0, 0.0, 1.0, 0.0,
           5.0, 6.0, 0.0, 1.0
         ]));
+
+    expect(parseTransform('rotate(20)\n\tscale(10)'),
+      Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
   });
 
   test('FillRule tests', () {


### PR DESCRIPTION
Given an SVG file with newlines or tabs in a `transform` attribute, `flutter_svg` will throw an exception.

For example, this SVG snippet:

```svg
<g transform="translate(1,1)
	scale(10)"></g>
```

Will cause this exception:

```
Bad state: Unsupported transform: 
  	scale
```

This PR addresses the issue by trimming extra whitespace from around the command, before trying to identify it.