### PR TITLE
throw if nested SVG encountered

### DIFF
--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -77,7 +77,37 @@ class _TextInfo {
 class _Elements {
   static Future<void> svg(SvgParserState parserState) {
     final DrawableViewport viewBox = parseViewBox(parserState.attributes);
-
+    // TODO(dnfield): Support nested SVG elements. https://github.com/dnfield/flutter_svg/issues/132
+    if (parserState._root != null) {
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: UnsupportedError('Unsupported nested <svg> element.'),
+        informationCollector: () sync* {
+          yield ErrorDescription(
+              'The root <svg> element contained an unsupported nested SVG element.');
+          if (parserState._key != null) {
+            yield ErrorDescription('');
+            yield DiagnosticsProperty<String>('Picture key', parserState._key);
+          }
+        },
+        library: 'SVG',
+        context: ErrorDescription('in _Element.svg'),
+      ));
+      parserState._parentDrawables.addLast(
+        _SvgGroupTuple(
+          'svg',
+          DrawableGroup(
+            <Drawable>[],
+            parseStyle(
+              parserState.attributes,
+              parserState._definitions,
+              viewBox.viewBoxRect,
+              null,
+            ),
+          ),
+        ),
+      );
+      return null;
+    }
     parserState._root = DrawableRoot(
       viewBox,
       <Drawable>[],

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -58,7 +58,7 @@ void main() {
     </g>
 </svg>''';
 
-  final Uint8List svg = utf8.encode(svgStr) as Uint8List;
+  final Uint8List svgBytes = utf8.encode(svgStr) as Uint8List;
 
   testWidgets('SvgPicture can work with a FittedBox',
       (WidgetTester tester) async {
@@ -177,7 +177,7 @@ void main() {
         child: RepaintBoundary(
           key: key,
           child: SvgPicture.memory(
-            svg,
+            svgBytes,
           ),
         ),
       ),
@@ -249,7 +249,7 @@ void main() {
       .thenAnswer((_) => Future<MockHttpClientResponse>.value(mockResponse));
 
   when(mockResponse.transform<Uint8List>(any))
-      .thenAnswer((_) => Stream<Uint8List>.fromIterable(<Uint8List>[svg]));
+      .thenAnswer((_) => Stream<Uint8List>.fromIterable(<Uint8List>[svgBytes]));
   when(mockResponse.listen(any,
           onDone: anyNamed('onDone'),
           onError: anyNamed('onError'),
@@ -264,7 +264,7 @@ void main() {
     final bool cancelOnError =
         invocation.namedArguments[#cancelOnError] as bool;
 
-    return Stream<Uint8List>.fromIterable(<Uint8List>[svg]).listen(
+    return Stream<Uint8List>.fromIterable(<Uint8List>[svgBytes]).listen(
       onData,
       onDone: onDone,
       onError: onError,
@@ -436,6 +436,12 @@ void main() {
     await tester.pumpAndSettle();
     await _checkWidgetAndGolden(key, 'text_color_filter.png');
   }, skip: !isLinux);
+
+  testWidgets('Nested SVG elements report a FlutterError', (WidgetTester tester) async {
+    await svg.fromSvgString('<svg viewBox="0 0 166 202"><svg viewBox="0 0 166 202"></svg></svg>', 'test');
+    final UnsupportedError error = tester.takeException() as UnsupportedError;
+    expect(error.message, 'Unsupported nested <svg> element.');
+  });
 }
 
 class MockAssetBundle extends Mock implements AssetBundle {}


### PR DESCRIPTION
Fixes lack of error reporting in #321 