### PR TITLE
Switch to Diagnosticable from DiagnosticableMixin

### DIFF
--- a/lib/src/picture_stream.dart
+++ b/lib/src/picture_stream.dart
@@ -85,7 +85,7 @@ typedef PictureListener = Function(PictureInfo image, bool synchronousCall);
 ///
 ///  * [PictureProvider], which has an example that includes the use of an
 ///    [PictureStream] in a [Widget].
-class PictureStream with DiagnosticableMixin {
+class PictureStream with Diagnosticable {
   /// Create an initially unbound image stream.
   ///
   /// Once an [PictureStreamCompleter] is available, call [setCompleter].
@@ -189,7 +189,7 @@ class PictureStream with DiagnosticableMixin {
 /// [PictureStreamListener] objects are rarely constructed directly. Generally, an
 /// [PictureProvider] subclass will return an [PictureStream] and automatically
 /// configure it with the right [PictureStreamCompleter] when possible.
-abstract class PictureStreamCompleter with DiagnosticableMixin {
+abstract class PictureStreamCompleter with Diagnosticable {
   final List<_PictureListenerPair> _listeners = <_PictureListenerPair>[];
   PictureInfo _current;
 


### PR DESCRIPTION
Now that `Diagnosticable` in Flutter's stable release is a mixin, use that instead, since `DiagnosticableMixin` will be going away. The two mixin classes are identical, so there should be no change in functionality.