### PR TITLE
Downgraded Flutter SDK version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.18.0-6.0.pre <2.0.0"
+  flutter: ">=1.17.0 <2.0.0"
 
 ## For developing features that require new functionality in engine:
 # dependency_overrides:


### PR DESCRIPTION
## Description
`flutter_svg` is depending on `1.18.0-6.0.pre`. Are there any reasons for this? This caused some problems (described #361). 

So I downgraded the min. Flutter SDK version to 1.17.0 (I'm not 100% sure, if this solves the problem).

```
flutter_svg:
  git:
    url: https://github.com/AndroidNils/flutter_svg.git
    ref: patch-1
```

## Related tickets
Closes #361 