### PR TITLE
Allow multiple transforms in an attribute 

### DIFF
--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -69,7 +69,7 @@ DrawableTextAnchorPosition parseTextAnchor(String raw) {
   }
 }
 
-const String _transformCommandAtom = ' *([^(]+)\\(([^)]*)\\)';
+const String _transformCommandAtom = ' *,?([^(]+)\\(([^)]*)\\)';
 final RegExp _transformValidator = RegExp('^($_transformCommandAtom)*\$');
 final RegExp _transformCommand = RegExp(_transformCommandAtom);
 

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -7,21 +7,29 @@ import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 void main() {
+  test('SVG Multiple transform parser tests', () {
+    Matrix4 expected = Matrix4.identity();
+    expected.translate(0.338957, 0.010104, 0);
+    expected.translate(-0.5214, 0.125, 0);
+    expected.translate(0.987, 0.789, 0);
+    expect(parseTransform('translate(0.338957,0.010104), translate(-0.5214,0.125),translate(0.987,0.789)'), expected);
+
+    expected = Matrix4.translationValues(0.338957, 0.010104, 0);
+    expected.scale(0.869768, 1.000000, 1.0);
+    expect(parseTransform('translate(0.338957,0.010104),scale(0.869768,1.000000)'), expected);
+  });
+
   test('SVG Transform parser tests', () {
     expect(() => parseTransform('invalid'), throwsStateError);
     expect(() => parseTransform('transformunsupported(0,0)'), throwsStateError);
 
     expect(parseTransform('skewX(60)'), Matrix4.skewX(60.0));
     expect(parseTransform('skewY(60)'), Matrix4.skewY(60.0));
-    expect(parseTransform('translate(10)'),
-        Matrix4.translationValues(10.0, 0.0, 0.0));
-    expect(parseTransform('translate(10, 15)'),
-        Matrix4.translationValues(10.0, 15.0, 0.0));
+    expect(parseTransform('translate(10,0.0)'), Matrix4.translationValues(10.0, 0.0, 0.0));
+    expect(parseTransform('skewX(60)'), Matrix4.skewX(60.0));
 
-    expect(parseTransform('scale(10)'),
-        Matrix4.identity()..scale(10.0, 10.0, 1.0));
-    expect(parseTransform('scale(10, 15)'),
-        Matrix4.identity()..scale(10.0, 15.0, 1.0));
+    expect(parseTransform('scale(10)'), Matrix4.identity()..scale(10.0, 10.0, 1.0));
+    expect(parseTransform('scale(10, 15)'), Matrix4.identity()..scale(10.0, 15.0, 1.0));
 
     expect(parseTransform('rotate(20)'), Matrix4.rotationZ(radians(20.0)));
     expect(


### PR DESCRIPTION
Regular Expression was including commas in the matching group. Added a small check to exclude any commas from matches and added tests to validate.