### PR TITLE
Expose SVG group and path 'id' attributes to DrawableRoot

### DIFF
--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -134,6 +134,7 @@ class _Elements {
         parent.style,
       ),
       transform: parseTransform(parserState.attribute('transform'))?.storage,
+      id: parserState.attribute('id'),
     );
     if (!parserState._inDefs) {
       parent.children.add(group);
@@ -847,6 +848,7 @@ class SvgParserState {
         defaultFillColor: colorBlack,
       ),
       transform: parseTransform(getAttribute(attributes, 'transform'))?.storage,
+      id: getAttribute(attributes, 'id'),
     );
     final bool isIri = checkForIri(drawable);
     if (!_inDefs || !isIri) {

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -988,7 +988,7 @@ class DrawableRoot implements DrawableParent {
 /// `stroke`, or `fill`.
 class DrawableGroup implements DrawableStyleable, DrawableParent {
   /// Creates a new DrawableGroup.
-  const DrawableGroup(this.children, this.style, {this.transform});
+  const DrawableGroup(this.children, this.style, {this.transform, this.id});
 
   @override
   final List<Drawable> children;
@@ -996,6 +996,9 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
   final DrawableStyle style;
   @override
   final Float64List transform;
+
+  /// SVG group 'id' attribute.
+  final String id;
 
   @override
   bool get hasDrawableContent => children != null && children.isNotEmpty;
@@ -1188,7 +1191,7 @@ class DrawableRasterImage implements DrawableStyleable {
 /// Represents a drawing element that will be rendered to the canvas.
 class DrawableShape implements DrawableStyleable {
   /// Creates a new [DrawableShape].
-  const DrawableShape(this.path, this.style, {this.transform})
+  const DrawableShape(this.path, this.style, {this.transform, this.id})
       : assert(path != null),
         assert(style != null);
 
@@ -1197,6 +1200,9 @@ class DrawableShape implements DrawableStyleable {
 
   @override
   final DrawableStyle style;
+
+  /// SVG path 'id' attribute.
+  final String id;
 
   /// The [Path] describing this shape.
   final Path path;


### PR DESCRIPTION
Exposing SVG group/path 'id' is essential to be able to identify and access specific groups/paths from a SVG file, at runtime.

At the most basic level, it allows for a simple inclusion/exclusion of specific groups/paths, before drawing to a canvas.
It can also allow for a runtime SVG modification (color, stroke, etc.).

There are many applications for such functionalities.