### PR TITLE
Changed property semanticsLabel to semanticLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGES
 
-## 0.19.1
+## 0.18.2
 
 - `semanticsLabel` property is now deprecated in `SvgPicture`
 - `semanticLabel` in `SvgPicture` may be used instead to add semantics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## 0.19.1
+
+- `semanticsLabel` property is now deprecated in `SvgPicture`
+- `semanticLabel` in `SvgPicture` may be used instead to add semantics
+
+
 ## 0.18.1
 
 - Change type of `alignment` to `AlignmentGeometry` on `SvgPicture`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Basic usage (to create an SVG rendering widget from an asset):
 final String assetName = 'assets/image.svg';
 final Widget svg = SvgPicture.asset(
   assetName,
-  semanticsLabel: 'Acme Logo'
+  semanticLabel: 'Acme Logo'
 );
 ```
 
@@ -41,7 +41,7 @@ final String assetName = 'assets/up_arrow.svg';
 final Widget svgIcon = SvgPicture.asset(
   assetName,
   color: Colors.red,
-  semanticsLabel: 'A red up arrow'
+  semanticLabel: 'A red up arrow'
 );
 ```
 
@@ -63,7 +63,7 @@ final Widget svg = SvgPicture.asset(
 
 final Widget networkSvg = SvgPicture.network(
   'https://site-that-takes-a-while.com/image.svg',
-  semanticsLabel: 'A shark?!',
+  semanticLabel: 'A shark?!',
   placeholderBuilder: (BuildContext context) => Container(
       padding: const EdgeInsets.all(30.0),
       child: const CircularProgressIndicator()),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,6 +64,7 @@ void main() {
   runApp(MyApp());
 }
 
+// ignore: public_member_api_docs
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -77,8 +78,11 @@ class MyApp extends StatelessWidget {
   }
 }
 
+// ignore: public_member_api_docs
 class MyHomePage extends StatefulWidget {
+  // ignore: public_member_api_docs
   const MyHomePage({Key key, this.title}) : super(key: key);
+  // ignore: public_member_api_docs
   final String title;
 
   @override

--- a/lib/avd.dart
+++ b/lib/avd.dart
@@ -75,13 +75,8 @@ class Avd {
         .map((XmlElement child) => parseAvdElement(child, viewBox.viewBoxRect))
         .toList();
     // todo : style on root
-    return DrawableRoot(
-      getAttribute(svg.attributes, 'id', def: ''),
-      viewBox,
-      children,
-      DrawableDefinitionServer(),
-      null
-    );
+    return DrawableRoot(getAttribute(svg.attributes, 'id', def: ''), viewBox,
+        children, DrawableDefinitionServer(), null);
   }
 }
 
@@ -168,11 +163,6 @@ DrawableRoot fromAvdString(String rawSvg, Rect size) {
       .map((XmlElement child) => parseAvdElement(child, size))
       .toList();
   // todo : style on root
-  return DrawableRoot(
-    getAttribute(svg.attributes, 'id', def: ''),
-    viewBox,
-    children,
-    DrawableDefinitionServer(),
-    null
-  );
+  return DrawableRoot(getAttribute(svg.attributes, 'id', def: ''), viewBox,
+      children, DrawableDefinitionServer(), null);
 }

--- a/lib/src/avd_parser.dart
+++ b/lib/src/avd_parser.dart
@@ -9,8 +9,12 @@ import 'avd/xml_parsers.dart';
 import 'vector_drawable.dart';
 
 class DrawableAvdRoot extends DrawableRoot {
-  const DrawableAvdRoot(String id, DrawableViewport viewBox, List<Drawable> children,
-      DrawableDefinitionServer definitions, DrawableStyle style)
+  const DrawableAvdRoot(
+      String id,
+      DrawableViewport viewBox,
+      List<Drawable> children,
+      DrawableDefinitionServer definitions,
+      DrawableStyle style)
       : super(id, viewBox, children, definitions, style);
 }
 

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -79,7 +79,7 @@ class _Elements {
   static Future<void> svg(SvgParserState parserState) {
     final DrawableViewport viewBox = parseViewBox(parserState.attributes);
     final String id = parserState.attribute('id', def: '');
-    
+
     // TODO(dnfield): Support nested SVG elements. https://github.com/dnfield/flutter_svg/issues/132
     if (parserState._root != null) {
       FlutterError.reportError(FlutterErrorDetails(

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -23,7 +23,6 @@ final Paint _grayscaleDstInPaint = Paint()
 /// Base interface for vector drawing.
 @immutable
 abstract class Drawable {
-
   /// A string that should uniquely identify this [Drawable] within its [DrawableRoot].
   String get id;
 
@@ -858,7 +857,6 @@ class DrawableRoot implements DrawableParent {
     this.style, {
     this.transform,
   });
-
 
   /// The expected coordinates used by child paths for drawing.
   final DrawableViewport viewport;

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -209,6 +209,7 @@ class SvgPicture extends StatefulWidget {
     this.matchTextDirection = false,
     this.allowDrawingOutsideViewBox = false,
     this.placeholderBuilder,
+    this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -305,6 +306,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
+    this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -360,6 +362,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
+    this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -411,6 +414,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
+    this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -458,6 +462,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
+    this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -505,6 +510,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
+    this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -600,6 +606,13 @@ class SvgPicture extends StatefulWidget {
   /// The value indicates the purpose of the picture, and will be
   /// read out by screen readers.
   final String semanticLabel;
+
+   /// The [Semantics.label] for this picture.
+  ///
+  /// The value indicates the purpose of the picture, and will be
+  /// read out by screen readers.
+  @Deprecated('This propert has been deprecated in the favour of semanticLabel')
+  final String semanticsLabel;
 
   /// Whether to exclude this picture from semantics.
   ///
@@ -708,11 +721,19 @@ class _SvgPictureState extends State<SvgPicture> {
     Widget _maybeWrapWithSemantics(Widget child) {
       if (widget.excludeFromSemantics) {
         return child;
-      }
-      return Semantics(
+      } else if (widget.semanticLabel != null) {
+         return Semantics(
         container: widget.semanticLabel != null,
         image: true,
         label: widget.semanticLabel == null ? '' : widget.semanticLabel,
+        child: child,
+      );
+      }
+      }
+      return Semantics(
+        container: widget.semanticsLabel != null,
+        image: true,
+        label: widget.semanticsLabel == null ? '' : widget.semanticsLabel,
         child: child,
       );
     }

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -611,7 +611,7 @@ class SvgPicture extends StatefulWidget {
   ///
   /// The value indicates the purpose of the picture, and will be
   /// read out by screen readers.
-  @Deprecated('This propert has been deprecated in the favour of semanticLabel')
+  @Deprecated('This property has been deprecated in the favour of semanticLabel')
   final String semanticsLabel;
 
   /// Whether to exclude this picture from semantics.

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -209,7 +209,8 @@ class SvgPicture extends StatefulWidget {
     this.matchTextDirection = false,
     this.allowDrawingOutsideViewBox = false,
     this.placeholderBuilder,
-    this.semanticsLabel,
+    @Deprecated('This property has been deprecated in favour of `semanticLabel`')
+        this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -306,7 +307,8 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    @Deprecated('This property has been deprecated in favour of `semanticLabel`')
+        this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -362,7 +364,8 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    @Deprecated('This property has been deprecated in favour of `semanticLabel`')
+        this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -414,7 +417,8 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    @Deprecated('This property has been deprecated in favour of `semanticLabel`')
+        this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -462,7 +466,8 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    @Deprecated('This property has been deprecated in favour of `semanticLabel`')
+        this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -510,7 +515,8 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    @Deprecated('This property has been deprecated in favour of `semanticLabel`')
+        this.semanticsLabel,
     this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
@@ -607,11 +613,12 @@ class SvgPicture extends StatefulWidget {
   /// read out by screen readers.
   final String semanticLabel;
 
-   /// The [Semantics.label] for this picture.
+  /// The [Semantics.label] for this picture.
   ///
   /// The value indicates the purpose of the picture, and will be
   /// read out by screen readers.
-  @Deprecated('This property has been deprecated in the favour of semanticLabel')
+  @Deprecated(
+      'This property has been deprecated in the favour of semanticLabel')
   final String semanticsLabel;
 
   /// Whether to exclude this picture from semantics.
@@ -721,19 +728,18 @@ class _SvgPictureState extends State<SvgPicture> {
     Widget _maybeWrapWithSemantics(Widget child) {
       if (widget.excludeFromSemantics) {
         return child;
-      } else if (widget.semanticLabel != null) {
-         return Semantics(
-        container: widget.semanticLabel != null,
-        image: true,
-        label: widget.semanticLabel == null ? '' : widget.semanticLabel,
-        child: child,
-      );
       }
-      }
+
+      // Check if the seprecated [widget.semanticsLabel] has been used
+      // If it is true and the new propert is `null` then
+      // [widget.semanticsLabel] will be used instead
+      final String semanticLabel =
+          widget.semanticLabel ?? widget.semanticsLabel;
+
       return Semantics(
-        container: widget.semanticsLabel != null,
+        container: semanticLabel != null,
         image: true,
-        label: widget.semanticsLabel == null ? '' : widget.semanticsLabel,
+        label: semanticLabel == null ? '' : semanticLabel,
         child: child,
       );
     }

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -195,7 +195,7 @@ class SvgPicture extends StatefulWidget {
   /// A custom `placeholderBuilder` can be specified for cases where decoding or
   /// acquiring data may take a noticeably long time, e.g. for a network picture.
   ///
-  /// The `semanticsLabel` can be used to identify the purpose of this picture for
+  /// The `semanticLabel` can be used to identify the purpose of this picture for
   /// screen reading software.
   ///
   /// If [excludeFromSemantics] is true, then [semanticLabel] will be ignored.
@@ -209,7 +209,7 @@ class SvgPicture extends StatefulWidget {
     this.matchTextDirection = false,
     this.allowDrawingOutsideViewBox = false,
     this.placeholderBuilder,
-    this.semanticsLabel,
+    this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
   }) : super(key: key);
@@ -305,7 +305,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
   })  : pictureProvider = ExactAssetPicture(
@@ -360,7 +360,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
   })  : pictureProvider = NetworkPicture(
@@ -411,7 +411,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
   })  : pictureProvider = FilePicture(
@@ -458,7 +458,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
   })  : pictureProvider = MemoryPicture(
@@ -505,7 +505,7 @@ class SvgPicture extends StatefulWidget {
     this.placeholderBuilder,
     Color color,
     BlendMode colorBlendMode = BlendMode.srcIn,
-    this.semanticsLabel,
+    this.semanticLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
   })  : pictureProvider = StringPicture(
@@ -599,7 +599,7 @@ class SvgPicture extends StatefulWidget {
   ///
   /// The value indicates the purpose of the picture, and will be
   /// read out by screen readers.
-  final String semanticsLabel;
+  final String semanticLabel;
 
   /// Whether to exclude this picture from semantics.
   ///
@@ -710,9 +710,9 @@ class _SvgPictureState extends State<SvgPicture> {
         return child;
       }
       return Semantics(
-        container: widget.semanticsLabel != null,
+        container: widget.semanticLabel != null,
         image: true,
-        label: widget.semanticsLabel == null ? '' : widget.semanticsLabel,
+        label: widget.semanticLabel == null ? '' : widget.semanticLabel,
         child: child,
       );
     }

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -108,7 +108,7 @@ void main() {
         }
       }
     }
-    return null;    
+    return null;
   }
 
   test('Font size parsing tests', () {
@@ -146,7 +146,7 @@ void main() {
 
   test('Check any ids', () async {
     const String svgStr =
-      '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+        '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <defs>
         <linearGradient id="triangleGradient">
             <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
@@ -178,7 +178,7 @@ void main() {
   });
 
   test('Check No Svg id', () async {
-  const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+    const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
 <svg width="27px" height="90px" viewBox="5 10 18 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
     <title>svg/stick_figure</title>

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -228,8 +228,8 @@ void main() {
               key: key,
               child: SvgPicture.asset(
                 'test.svg',
-                //TODO: Change this field to [semanticLabel]
                 semanticsLabel: 'Test SVG',
+                semanticLabel: 'Test SVG',
               ),
             ),
           ),
@@ -336,6 +336,7 @@ void main() {
           child: SvgPicture.string(
             svgStr,
             semanticsLabel: 'Flutter Logo',
+            semanticLabel: 'Flutter Logo',
             width: 100.0,
             height: 100.0,
           ),

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -228,6 +228,7 @@ void main() {
               key: key,
               child: SvgPicture.asset(
                 'test.svg',
+                //TODO: Change this field to [semanticLabel]
                 semanticsLabel: 'Test SVG',
               ),
             ),


### PR DESCRIPTION
Since the entire flutter framework uses `semancicLabel`, it becomes confusing and also if we are migrating from `Image`, it's cumbersome to change `semanticsLabel` to `semanticLabel`.