### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/avd.dart
+++ b/lib/avd.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: public_member_api_docs
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui' show Picture;

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:xml/xml_events.dart' as xml show parseEvents;
 
 import 'src/svg/parser_state.dart';

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:collection';
 import 'dart:ui';
 

--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert' hide Codec;
 import 'dart:math';
 import 'dart:typed_data';

--- a/lib/src/utilities/_http_io.dart
+++ b/lib/src/utilities/_http_io.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 

--- a/lib/src/utilities/_http_web.dart
+++ b/lib/src/utilities/_http_web.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
 import 'dart:typed_data';

--- a/tool/gen_golden.dart
+++ b/tool/gen_golden.dart
@@ -5,7 +5,6 @@
 // The golden files should then be visually compared against Chrome's rendering output for correctness.
 // The comparison may have to be made more tolerant if we want to use other sources of rendering for comparison...
 
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';


### PR DESCRIPTION
As of Dart 2.1, Future and Stream are exported by dart:core