### PR TITLE
Prepare for dry layout feature

### DIFF
--- a/lib/src/render_picture.dart
+++ b/lib/src/render_picture.dart
@@ -150,9 +150,11 @@ class RenderPicture extends RenderBox {
   @override
   bool get sizedByParent => true;
 
+  // TODO(goderbauer): Remove the ignore when https://github.com/flutter/flutter/pull/70656 has landed.
   @override
-  void performResize() {
-    size = constraints.smallest;
+  // ignore: override_on_non_overriding_member
+  Size computeDryLayout(BoxConstraints constraints) {
+    return constraints.smallest;
   }
 
   @override


### PR DESCRIPTION
Prepare for introduction of dry layout in https://github.com/flutter/flutter/pull/70656.

This needs to roll into google before https://github.com/flutter/flutter/pull/70656 can be rolled in.

Please wait with submitting this until https://github.com/flutter/flutter/pull/70656 is approved.