### PR TITLE
Ignore dead code warning in preparation for flow analysis improvement.

### DIFF
--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -159,9 +159,6 @@ class PictureConfiguration {
     result.write('PictureConfiguration(');
     bool hasArguments = false;
     if (bundle != null) {
-      if (hasArguments) { // ignore: dead_code
-        result.write(', ');
-      }
       result.write('bundle: $bundle');
       hasArguments = true;
     }

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -159,7 +159,7 @@ class PictureConfiguration {
     result.write('PictureConfiguration(');
     bool hasArguments = false;
     if (bundle != null) {
-      if (hasArguments) {
+      if (hasArguments) { // ignore: dead_code
         result.write(', ');
       }
       result.write('bundle: $bundle');


### PR DESCRIPTION
When https://github.com/dart-lang/language/issues/1274 (Infer
non-nullability from local boolean variables) is implemented, flow
analysis will detect that code like this is unreachable:

    bool hasArguments = false;
    ...
    if (hasArguments) {
      // Not reachable
    }

To prepare for this improvement, we need to add an "ignore" comment to
ignore the dead_code warning that will be generated.