### PR TITLE
Return valid type from Future.catchError.

### DIFF
--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -601,7 +601,7 @@ class FilePicture extends PictureProvider<FilePicture> {
         key.toString(),
       ).catchError((Object error, StackTrace stack) async {
         onError(error, stack);
-        return null;
+        return Future<PictureInfo>.error(error, stack);
       });
     }
     return decoder(data, colorFilter, key.toString());


### PR DESCRIPTION
An upcoming feature to the Dart analyzer [0] will report Future.catchError [1]
`onError` handlers which return values of invalid type. Currently this is not
reported because the `onError` handler function type cannot be accurately
expressed. An `onError` handler for `Future<T>.catchError` must be either
`FutureOr<T> Function(dynamic)` or `FutureOr<T> Function(dynamic, StackTrace)`.
In either case, the return type of the function is `FutureOr<T>`.

This CL corrects `onError` handler(s) to return a value of a valid type.

[0]: https://github.com/dart-lang/sdk/issues/35825
[1]: https://api.dart.dev/dev/2.12.0-149.0.dev/dart-async/Future/catchError.html