### PR TITLE
Add warningsAsErrors option for parsing SVGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## 0.20.0-nullsafety.4
+
+- Adds a dry-run mode to check if an SVG is supported.
+
 ## 0.20.0-nullsafety.3
 
 - Fix broken image for pub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.20.0-nullsafety.4
 
-- Adds a dry-run mode to check if an SVG is supported.
+- Adds option `warningsAsErrors` that throws errors when detecting unsupported SVG elements.
 
 ## 0.20.0-nullsafety.3
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,15 @@ See [main.dart](/../master/example/lib/main.dart) for a complete sample.
 
 ## Check SVG compatibility
 
-As not all SVG features are supported by this library (see below), sometimes we have to dynamically check if an SVG contains any unsupported features resulting in broken images. This can be done by using the snippet below:
+As not all SVG features are supported by this library (see below), sometimes we have to dynamically
+check if an SVG contains any unsupported features resulting in broken images.
+You might also want to throw errors in tests, but only warn about them at runtime.
+This can be done by using the snippet below:
 
 ```dart
 final SvgParser parser = SvgParser();
 try {
-  parser.parse(svgString, dryRun: true);
+  parser.parse(svgString, warningsAsErrors: true);
   print('SVG is supported');
 } catch (e) {
   print('SVG contains unsupported features');

--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ mechanism for rendering rather than `Image`s.
 
 See [main.dart](/../master/example/lib/main.dart) for a complete sample.
 
+## Check SVG compatibility
+
+As not all SVG features are supported by this library (see below), sometimes we have to dynamically check if an SVG contains any unsupported features resulting in broken images. This can be done by using the snippet below:
+
+```dart
+final SvgParser parser = SvgParser();
+try {
+  parser.parse(svgString, dryRun: true);
+  print('SVG is supported');
+} catch (e) {
+  print('SVG contains unsupported features');
+}
+```
+
+> Note:
+> The library currently only detects unsupported elements (like the `<style>`-tag), but not unsupported attributes.
+
 ## Use Cases
 
 - Your designer creates a vector asset that you want to include without

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -8,8 +8,18 @@ class SvgParser {
   /// Parses SVG from a string to a [DrawableRoot].
   ///
   /// The [key] parameter is used for debugging purposes.
-  Future<DrawableRoot> parse(String str, {String? key}) async {
-    final SvgParserState state = SvgParserState(xml.parseEvents(str), key);
+  ///
+  /// The [dryRun] detects if an SVG contains contains unsupported features.
+  /// If true the function will throw with an error.
+  /// If false only warnings are logged to the console.
+  /// Defaults to false.
+  Future<DrawableRoot> parse(
+    String str, {
+    String? key,
+    bool dryRun = false,
+  }) async {
+    final SvgParserState state =
+        SvgParserState(xml.parseEvents(str), key, dryRun);
     return await state.parse();
   }
 }

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -9,17 +9,19 @@ class SvgParser {
   ///
   /// The [key] parameter is used for debugging purposes.
   ///
-  /// The [dryRun] detects if an SVG contains contains unsupported features.
-  /// If true the function will throw with an error.
-  /// If false only warnings are logged to the console.
+  /// By default SVG parsing will only log warnings when detecting unsupported
+  /// elements in an SVG.
+  /// If [warningsAsErrors] is true the function will throw with an error
+  /// instead.
+  /// You might want to set this to true for test and to false at runtime.
   /// Defaults to false.
   Future<DrawableRoot> parse(
     String str, {
     String? key,
-    bool dryRun = false,
+    bool warningsAsErrors = false,
   }) async {
     final SvgParserState state =
-        SvgParserState(xml.parseEvents(str), key, dryRun);
+        SvgParserState(xml.parseEvents(str), key, warningsAsErrors);
     return await state.parse();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 homepage: https://github.com/dnfield/flutter_svg
-version: 0.20.0-nullsafety.3
+version: 0.20.0-nullsafety.4
 
 dependencies:
   flutter:

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -205,4 +205,56 @@ void main() {
     expect(find<DrawableGroup>(root, 'stick_figure') != null, true);
     expect(find<DrawableShape>(root, 'Oval') != null, true);
   });
+
+  test('Throws with unsupported elements in dry run', () async {
+    const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg width="27px" height="90px" viewBox="5 10 18 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
+    <title>svg/stick_figure</title>
+    <desc>Created with Sketch.</desc>
+    <style> #Oval { fill: #D8D8D8; } </style>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="iPhone-8" transform="translate(-53.000000, -359.000000)" stroke="#979797">
+            <g id="stick_figure" transform="translate(53.000000, 359.000000)">
+                <ellipse id="Oval" cx="13.5" cy="12" rx="12" ry="11.5"></ellipse>
+                <path d="M13.5,24 L13.5,71.5" id="Line" stroke-linecap="square"></path>
+                <path d="M13.5,71.5 L1,89.5" id="Line-1" stroke-linecap="square"></path>
+                <path d="M13.5,37.5 L1,55.5" id="Line-2" stroke-linecap="square"></path>
+                <path d="M26.5,71.5 L14,89.5" id="Line-3" stroke-linecap="square" transform="translate(20.000000, 80.500000) scale(-1, 1) translate(-20.000000, -80.500000) "></path>
+                <path d="M26.5,37.5 L14,55.5" id="Line-2-Copy" stroke-linecap="square" transform="translate(20.000000, 46.500000) scale(-1, 1) translate(-20.000000, -46.500000) "></path>
+            </g>
+        </g>
+    </g>
+</svg>''';
+    final SvgParser parser = SvgParser();
+    expect(
+      parser.parse(svgStr, dryRun: true),
+      throwsA(anything),
+    );
+  });
+
+  test('Warns about unsupported elements by default', () async {
+    const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg width="27px" height="90px" viewBox="5 10 18 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
+    <title>svg/stick_figure</title>
+    <desc>Created with Sketch.</desc>
+    <style> #Oval { fill: #D8D8D8; } </style>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="iPhone-8" transform="translate(-53.000000, -359.000000)" stroke="#979797">
+            <g id="stick_figure" transform="translate(53.000000, 359.000000)">
+                <ellipse id="Oval" cx="13.5" cy="12" rx="12" ry="11.5"></ellipse>
+                <path d="M13.5,24 L13.5,71.5" id="Line" stroke-linecap="square"></path>
+                <path d="M13.5,71.5 L1,89.5" id="Line-1" stroke-linecap="square"></path>
+                <path d="M13.5,37.5 L1,55.5" id="Line-2" stroke-linecap="square"></path>
+                <path d="M26.5,71.5 L14,89.5" id="Line-3" stroke-linecap="square" transform="translate(20.000000, 80.500000) scale(-1, 1) translate(-20.000000, -80.500000) "></path>
+                <path d="M26.5,37.5 L14,55.5" id="Line-2-Copy" stroke-linecap="square" transform="translate(20.000000, 46.500000) scale(-1, 1) translate(-20.000000, -46.500000) "></path>
+            </g>
+        </g>
+    </g>
+</svg>''';
+
+    final SvgParser parser = SvgParser();
+    expect(await parser.parse(svgStr), isA<DrawableRoot>());
+  });
 }

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -206,7 +206,8 @@ void main() {
     expect(find<DrawableShape>(root, 'Oval') != null, true);
   });
 
-  test('Throws with unsupported elements in dry run', () async {
+  test('Throws with unsupported elements with warnings as errors enabled',
+      () async {
     const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
 <svg width="27px" height="90px" viewBox="5 10 18 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
@@ -228,7 +229,7 @@ void main() {
 </svg>''';
     final SvgParser parser = SvgParser();
     expect(
-      parser.parse(svgStr, dryRun: true),
+      parser.parse(svgStr, warningsAsErrors: true),
       throwsA(anything),
     );
   });


### PR DESCRIPTION
## Description

Adds a dry run mode which will always throw an error aborting the rendering process.

The dry run can be used to check if an SVG is supported by the library.

## Related Issues

Closes #473 