### PR TITLE
Remove return stmts from Future<void>.catchError

### DIFF
--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -340,6 +340,7 @@ abstract class PictureProvider<T> {
     ).catchError((Object exception, StackTrace stack) async {
       if (onError != null) {
         onError(exception, stack);
+        return;
       }
       FlutterError.reportError(FlutterErrorDetails(
           exception: exception,

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -353,7 +353,6 @@ abstract class PictureProvider<T> {
             yield DiagnosticsProperty<T>('Picture key', obtainedKey,
                 defaultValue: null);
           }));
-      return null;
     });
     return stream;
   }

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -340,7 +340,6 @@ abstract class PictureProvider<T> {
     ).catchError((Object exception, StackTrace stack) async {
       if (onError != null) {
         onError(exception, stack);
-        return Future<PictureStream>.error(exception, stack);
       }
       FlutterError.reportError(FlutterErrorDetails(
           exception: exception,


### PR DESCRIPTION
A similar, but oddly reversed, fix to https://github.com/dnfield/flutter_svg/commit/272f9929f009e0b4e1413095ab4d2e3f3233b8d8.

The issue here is that a `Future<void>`'s catchError onError handler should return `void`. I think this fix is a no-op, because the `Future<PictureStream>` was immediately dropped on the floor. I the important bit in there (`onError(exception, stack);`) remains.

The dart analyzer will start reporting code like this when https://github.com/dart-lang/sdk/issues/35825 is closed.