### PR TITLE
Refactor attribute localName check

### DIFF
--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -59,7 +59,7 @@ String _getAttribute(
   String? namespace,
 }) {
   for (XmlEventAttribute attr in list) {
-    if (attr.name.replaceFirst('${attr.namespacePrefix}:', '') == localName) {
+    if (attr.localName == localName) {
       return attr.value;
     }
   }


### PR DESCRIPTION
Existing implementation uses replaceFirst API which will create a new String. This change replaces it with `localName` API of XmlEventAttribute which internally uses substring.

The end result is overall faster parsing.