### PR TITLE
Improve performance of SVG parsing

### DIFF
--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -750,7 +750,7 @@ class SvgParserState {
         depth -= 1;
         assert(depth >= 0);
       }
-      _currentAttributes = {};
+      _currentAttributes = <String, String>{};
       _currentStartElement = null;
       if (depth < subtreeStartDepth) {
         return;
@@ -764,7 +764,7 @@ class SvgParserState {
       final XmlEvent event = _eventIterator.current;
       bool isSelfClosing = false;
       if (event is XmlStartElementEvent) {
-        final attributeMap = event.attributes.toAttributeMap();
+        final Map<String, String> attributeMap = event.attributes.toAttributeMap();
         if (getAttribute(attributeMap, 'display') == 'none' ||
             getAttribute(attributeMap, 'visibility') == 'hidden') {
           print('SVG Warning: Discarding:\n\n  $event\n\n'
@@ -789,7 +789,7 @@ class SvgParserState {
       if (isSelfClosing || event is XmlEndElementEvent) {
         depth -= 1;
         assert(depth >= 0);
-        _currentAttributes = {};
+        _currentAttributes = <String, String>{};
         _currentStartElement = null;
       }
       if (depth < subtreeStartDepth) {

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -18,7 +18,7 @@ final Set<String> _unhandledElements = <String>{'title', 'desc'};
 
 typedef _ParseFunc = Future<void>? Function(
     SvgParserState parserState, bool warningsAsErrors);
-typedef _PathFunc = Path? Function(List<XmlEventAttribute>? attributes);
+typedef _PathFunc = Path? Function(Map<String, String> attributes);
 
 const Map<String, _ParseFunc> _svgElementParsers = <String, _ParseFunc>{
   'svg': _Elements.svg,
@@ -635,7 +635,7 @@ class _Elements {
 }
 
 class _Paths {
-  static Path circle(List<XmlEventAttribute>? attributes) {
+  static Path circle(Map<String, String> attributes) {
     final double cx = parseDouble(getAttribute(attributes, 'cx', def: '0'))!;
     final double cy = parseDouble(getAttribute(attributes, 'cy', def: '0'))!;
     final double r = parseDouble(getAttribute(attributes, 'r', def: '0'))!;
@@ -643,12 +643,12 @@ class _Paths {
     return Path()..addOval(oval);
   }
 
-  static Path path(List<XmlEventAttribute>? attributes) {
+  static Path path(Map<String, String> attributes) {
     final String d = getAttribute(attributes, 'd')!;
     return parseSvgPathData(d);
   }
 
-  static Path rect(List<XmlEventAttribute>? attributes) {
+  static Path rect(Map<String, String> attributes) {
     final double x = parseDouble(getAttribute(attributes, 'x', def: '0'))!;
     final double y = parseDouble(getAttribute(attributes, 'y', def: '0'))!;
     final double w = parseDouble(getAttribute(attributes, 'width', def: '0'))!;
@@ -669,16 +669,16 @@ class _Paths {
     return Path()..addRect(rect);
   }
 
-  static Path? polygon(List<XmlEventAttribute>? attributes) {
+  static Path? polygon(Map<String, String> attributes) {
     return parsePathFromPoints(attributes, true);
   }
 
-  static Path? polyline(List<XmlEventAttribute>? attributes) {
+  static Path? polyline(Map<String, String> attributes) {
     return parsePathFromPoints(attributes, false);
   }
 
   static Path? parsePathFromPoints(
-      List<XmlEventAttribute>? attributes, bool close) {
+      Map<String, String> attributes, bool close) {
     final String? points = getAttribute(attributes, 'points');
     if (points == '') {
       return null;
@@ -688,7 +688,7 @@ class _Paths {
     return parseSvgPathData(path);
   }
 
-  static Path ellipse(List<XmlEventAttribute>? attributes) {
+  static Path ellipse(Map<String, String> attributes) {
     final double cx = parseDouble(getAttribute(attributes, 'cx', def: '0'))!;
     final double cy = parseDouble(getAttribute(attributes, 'cy', def: '0'))!;
     final double rx = parseDouble(getAttribute(attributes, 'rx', def: '0'))!;
@@ -698,7 +698,7 @@ class _Paths {
     return Path()..addOval(r);
   }
 
-  static Path line(List<XmlEventAttribute>? attributes) {
+  static Path line(Map<String, String> attributes) {
     final double x1 = parseDouble(getAttribute(attributes, 'x1', def: '0'))!;
     final double x2 = parseDouble(getAttribute(attributes, 'x2', def: '0'))!;
     final double y1 = parseDouble(getAttribute(attributes, 'y1', def: '0'))!;
@@ -734,7 +734,7 @@ class SvgParserState {
   final Queue<_SvgGroupTuple> _parentDrawables = ListQueue<_SvgGroupTuple>(10);
   DrawableRoot? _root;
   bool _inDefs = false;
-  List<XmlEventAttribute>? _currentAttributes;
+  late Map<String, String> _currentAttributes;
   XmlStartElementEvent? _currentStartElement;
 
   /// The current depth of the reader in the XML hierarchy.
@@ -750,7 +750,7 @@ class SvgParserState {
         depth -= 1;
         assert(depth >= 0);
       }
-      _currentAttributes = <XmlEventAttribute>[];
+      _currentAttributes = {};
       _currentStartElement = null;
       if (depth < subtreeStartDepth) {
         return;
@@ -764,8 +764,9 @@ class SvgParserState {
       final XmlEvent event = _eventIterator.current;
       bool isSelfClosing = false;
       if (event is XmlStartElementEvent) {
-        if (getAttribute(event.attributes, 'display') == 'none' ||
-            getAttribute(event.attributes, 'visibility') == 'hidden') {
+        final attributeMap = event.attributes.toAttributeMap();
+        if (getAttribute(attributeMap, 'display') == 'none' ||
+            getAttribute(attributeMap, 'visibility') == 'hidden') {
           print('SVG Warning: Discarding:\n\n  $event\n\n'
               'and any children it has since it is not visible.\n'
               'If that element is meant to be visible, the `display` or '
@@ -778,7 +779,7 @@ class SvgParserState {
           }
           continue;
         }
-        _currentAttributes = event.attributes;
+        _currentAttributes = attributeMap;
         _currentStartElement = event;
         depth += 1;
         isSelfClosing = event.isSelfClosing;
@@ -788,7 +789,7 @@ class SvgParserState {
       if (isSelfClosing || event is XmlEndElementEvent) {
         depth -= 1;
         assert(depth >= 0);
-        _currentAttributes = <XmlEventAttribute>[];
+        _currentAttributes = {};
         _currentStartElement = null;
       }
       if (depth < subtreeStartDepth) {
@@ -826,11 +827,11 @@ class SvgParserState {
   }
 
   /// The XML Attributes of the current node in the tree.
-  List<XmlEventAttribute>? get attributes => _currentAttributes;
+  Map<String, String> get attributes => _currentAttributes;
 
   /// Gets the attribute for the current position of the parser.
-  String? attribute(String name, {String? def, String? namespace}) =>
-      getAttribute(attributes, name, def: def, namespace: namespace);
+  String? attribute(String name, {String? def}) =>
+      getAttribute(attributes, name, def: def);
 
   /// The current group, if any, in the [Drawable] heirarchy.
   DrawableParent? get currentGroup {

--- a/lib/src/svg/xml_parsers.dart
+++ b/lib/src/svg/xml_parsers.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:path_drawing/path_drawing.dart';
 import 'package:vector_math/vector_math_64.dart';
-import 'package:xml/xml_events.dart';
 
 import '../utilities/errors.dart';
 import '../utilities/numbers.dart';
@@ -38,7 +37,7 @@ double _parseRawWidthHeight(String? raw) {
 /// The [respectWidthHeight] parameter specifies whether `width` and `height` attributes
 /// on the root SVG element should be treated in accordance with the specification.
 DrawableViewport? parseViewBox(
-  List<XmlEventAttribute>? svg, {
+    Map<String, String> svg, {
   bool nullOk = false,
 }) {
   final String? viewBox = getAttribute(svg, 'viewBox');
@@ -86,14 +85,14 @@ DrawableViewport? parseViewBox(
 }
 
 /// Builds an IRI in the form of `'url(#id)'`.
-String buildUrlIri(List<XmlEventAttribute>? attributes) =>
+String buildUrlIri(Map<String, String> attributes) =>
     'url(#${getAttribute(attributes, 'id')})';
 
 /// An empty IRI.
 const String emptyUrlIri = 'url(#)';
 
 /// Parses a `spreadMethod` attribute into a [TileMode].
-TileMode parseTileMode(List<XmlEventAttribute>? attributes) {
+TileMode parseTileMode(Map<String, String> attributes) {
   final String? spreadMethod =
       getAttribute(attributes, 'spreadMethod', def: 'pad');
   switch (spreadMethod) {
@@ -112,7 +111,7 @@ TileMode parseTileMode(List<XmlEventAttribute>? attributes) {
 ///
 /// Does not currently support percentages.
 CircularIntervalList<double>? parseDashArray(
-  List<XmlEventAttribute>? attributes,
+  Map<String, String> attributes,
 ) {
   final String? rawDashArray = getAttribute(attributes, 'stroke-dasharray');
   if (rawDashArray == '') {
@@ -127,7 +126,7 @@ CircularIntervalList<double>? parseDashArray(
 }
 
 /// Parses a @stroke-dashoffset into a [DashOffset].
-DashOffset? parseDashOffset(List<XmlEventAttribute>? attributes) {
+DashOffset? parseDashOffset(Map<String, String> attributes) {
   final String? rawDashOffset = getAttribute(attributes, 'stroke-dashoffset');
   if (rawDashOffset == '') {
     return null;
@@ -144,7 +143,7 @@ DashOffset? parseDashOffset(List<XmlEventAttribute>? attributes) {
 }
 
 /// Parses an @opacity value into a [double], clamped between 0..1.
-double? parseOpacity(List<XmlEventAttribute>? attributes) {
+double? parseOpacity(Map<String, String> attributes) {
   final String? rawOpacity = getAttribute(attributes, 'opacity', def: null);
   if (rawOpacity != null) {
     return parseDouble(rawOpacity)!.clamp(0.0, 1.0).toDouble();
@@ -175,7 +174,7 @@ DrawablePaint _getDefinitionPaint(
 /// Parses a @stroke attribute into a [Paint].
 DrawablePaint? parseStroke(
   String? key,
-  List<XmlEventAttribute>? attributes,
+  Map<String, String> attributes,
   Rect? bounds,
   DrawableDefinitionServer definitions,
   DrawablePaint? parentStroke,
@@ -244,7 +243,7 @@ DrawablePaint? parseStroke(
 /// Parses a `fill` attribute.
 DrawablePaint? parseFill(
   String? key,
-  List<XmlEventAttribute>? el,
+    Map<String, String> el,
   Rect? bounds,
   DrawableDefinitionServer definitions,
   DrawablePaint? parentFill,
@@ -304,14 +303,14 @@ Color? _determineFillColor(
 }
 
 /// Parses a `fill-rule` attribute into a [PathFillType].
-PathFillType? parseFillRule(List<XmlEventAttribute>? attributes,
+PathFillType? parseFillRule(Map<String, String> attributes,
     [String attr = 'fill-rule', String? def = 'nonzero']) {
   final String? rawFillRule = getAttribute(attributes, attr, def: def);
   return parseRawFillRule(rawFillRule);
 }
 
 /// Applies a transform to a path if the [attributes] contain a `transform`.
-Path? applyTransformIfNeeded(Path? path, List<XmlEventAttribute>? attributes) {
+Path? applyTransformIfNeeded(Path? path, Map<String, String> attributes) {
   final Matrix4? transform =
       parseTransform(getAttribute(attributes, 'transform', def: null));
 
@@ -324,7 +323,7 @@ Path? applyTransformIfNeeded(Path? path, List<XmlEventAttribute>? attributes) {
 
 /// Parses a `clipPath` element into a list of [Path]s.
 List<Path>? parseClipPath(
-  List<XmlEventAttribute>? attributes,
+  Map<String, String> attributes,
   DrawableDefinitionServer definitions,
 ) {
   final String? rawClipAttribute = getAttribute(attributes, 'clip-path');
@@ -355,7 +354,7 @@ const Map<String, BlendMode> _blendModes = <String, BlendMode>{
 
 /// Lookup the mask if the attribute is present.
 DrawableStyleable? parseMask(
-  List<XmlEventAttribute>? attributes,
+  Map<String, String> attributes,
   DrawableDefinitionServer definitions,
 ) {
   final String? rawMaskAttribute = getAttribute(attributes, 'mask');
@@ -402,7 +401,7 @@ FontWeight? parseFontWeight(String? fontWeight) {
 /// Remember that @style attribute takes precedence.
 DrawableStyle parseStyle(
   String? key,
-  List<XmlEventAttribute>? attributes,
+  Map<String, String> attributes,
   DrawableDefinitionServer definitions,
   Rect? bounds,
   DrawableStyle? parentStyle, {

--- a/lib/src/utilities/numbers.dart
+++ b/lib/src/utilities/numbers.dart
@@ -8,7 +8,7 @@ double? parseDouble(String? maybeDouble, {bool tryParse = false}) {
   if (maybeDouble == null) {
     return null;
   }
-  maybeDouble = maybeDouble.trim().replaceFirst('px', '').trim();
+  maybeDouble = maybeDouble.replaceFirst('px', '').trim();
   if (tryParse) {
     return double.tryParse(maybeDouble);
   }

--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -7,10 +7,9 @@ const String kXlinkNamespace = 'http://www.w3.org/1999/xlink';
 ///
 /// SVG 1.1 specifies that these attributes should be in the xlink namespace.
 /// SVG 2 deprecates that namespace.
-String? getHrefAttribute(List<XmlEventAttribute>? attributes) => getAttribute(
+String? getHrefAttribute(Map<String, String> attributes) => getAttribute(
       attributes,
       'href',
-      namespace: kXlinkNamespace,
       def: getAttribute(attributes, 'href'),
     );
 
@@ -19,15 +18,14 @@ String? getHrefAttribute(List<XmlEventAttribute>? attributes) => getAttribute(
 ///
 /// Will look to the style first if it can.
 String? getAttribute(
-  List<XmlEventAttribute>? el,
+  Map<String, String> el,
   String name, {
   String? def = '',
-  String? namespace,
   bool checkStyle = true,
 }) {
   String raw = '';
   if (checkStyle) {
-    final String? style = _getAttribute(el!, 'style').trim();
+    final String? style = _getAttribute(el, 'style');
     if (style != '' && style != null) {
       // Probably possible to slightly optimize this (e.g. use indexOf instead of split),
       // but handling potential whitespace will get complicated and this just works.
@@ -43,25 +41,25 @@ String? getAttribute(
     }
 
     if (raw == '') {
-      raw = _getAttribute(el, name, namespace: namespace).trim();
+      raw = _getAttribute(el, name);
     }
   } else {
-    raw = _getAttribute(el!, name, namespace: namespace).trim();
+    raw = _getAttribute(el, name);
   }
 
   return raw == '' ? def : raw;
 }
 
 String _getAttribute(
-  List<XmlEventAttribute> list,
+  Map<String, String> attributes,
   String localName, {
   String def = '',
-  String? namespace,
 }) {
-  for (XmlEventAttribute attr in list) {
-    if (attr.localName == localName) {
-      return attr.value;
-    }
-  }
-  return def;
+  return attributes[localName] ?? def;
+}
+
+extension AttributeMapXmlEventAttributeExtension on List<XmlEventAttribute> {
+  Map<String, String> toAttributeMap() => {
+    for (final attribute in this) attribute.localName: attribute.value.trim(),
+  };
 }

--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -58,8 +58,12 @@ String _getAttribute(
   return attributes[localName] ?? def;
 }
 
+/// Extension on List<XmlEventAttribute> for easy conversion to an attribute
+/// map.
 extension AttributeMapXmlEventAttributeExtension on List<XmlEventAttribute> {
-  Map<String, String> toAttributeMap() => {
-    for (final attribute in this) attribute.localName: attribute.value.trim(),
+  /// Converts the List<XmlEventAttribute> to an attribute map.
+  Map<String, String> toAttributeMap() => <String, STring>{
+    for (final XmlEventAttribute attribute in this)
+      attribute.localName: attribute.value.trim(),
   };
 }

--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -62,7 +62,7 @@ String _getAttribute(
 /// map.
 extension AttributeMapXmlEventAttributeExtension on List<XmlEventAttribute> {
   /// Converts the List<XmlEventAttribute> to an attribute map.
-  Map<String, String> toAttributeMap() => <String, STring>{
+  Map<String, String> toAttributeMap() => <String, String>{
     for (final XmlEventAttribute attribute in this)
       attribute.localName: attribute.value.trim(),
   };

--- a/test/xml_svg_test.dart
+++ b/test/xml_svg_test.dart
@@ -17,8 +17,8 @@ void main() {
                 'xlink:href="http://localhost" />')
             .first as XmlStartElementEvent;
 
-    expect(getHrefAttribute(el.attributes), 'http://localhost');
-    expect(getHrefAttribute(elXlink.attributes), 'http://localhost');
+    expect(getHrefAttribute(el.attributes.toAttributeMap()), 'http://localhost');
+    expect(getHrefAttribute(elXlink.attributes.toAttributeMap()), 'http://localhost');
   });
 
   test('Attribute and style tests', () {
@@ -27,15 +27,16 @@ void main() {
                 'style="stroke-opacity:1;fill-opacity:.23" />')
             .first as XmlStartElementEvent;
 
-    expect(getAttribute(el.attributes, 'stroke'), '#fff');
-    expect(getAttribute(el.attributes, 'fill'), '#eee');
-    expect(getAttribute(el.attributes, 'stroke-dashpattern'), '1 2');
-    expect(getAttribute(el.attributes, 'stroke-opacity'), '1');
-    expect(getAttribute(el.attributes, 'stroke-another'), '');
-    expect(getAttribute(el.attributes, 'fill-opacity'), '.23');
+    final attributes = el.attributes.toAttributeMap();
+    expect(getAttribute(attributes, 'stroke'), '#fff');
+    expect(getAttribute(attributes, 'fill'), '#eee');
+    expect(getAttribute(attributes, 'stroke-dashpattern'), '1 2');
+    expect(getAttribute(attributes, 'stroke-opacity'), '1');
+    expect(getAttribute(attributes, 'stroke-another'), '');
+    expect(getAttribute(attributes, 'fill-opacity'), '.23');
 
-    expect(getAttribute(el.attributes, 'fill-opacity', checkStyle: false), '');
-    expect(getAttribute(el.attributes, 'fill', checkStyle: false), '#eee');
+    expect(getAttribute(attributes, 'fill-opacity', checkStyle: false), '');
+    expect(getAttribute(attributes, 'fill', checkStyle: false), '#eee');
   });
 
   // if the parsing logic changes, we can simplify some methods.  for now assert that whitespace in attributes is preserved
@@ -76,17 +77,17 @@ void main() {
     final XmlStartElementEvent svgWithNoSizeInfo =
         parseEvents('<svg />').first as XmlStartElementEvent;
 
-    expect(parseViewBox(svgWithViewBoxAndWidthHeight.attributes)!.size,
+    expect(parseViewBox(svgWithViewBoxAndWidthHeight.attributes.toAttributeMap())!.size,
         const Size(50, 50));
-    expect(parseViewBox(svgWithViewBox.attributes)!.viewBoxRect, rect);
-    expect(parseViewBox(svgWithViewBox.attributes)!.viewBoxOffset, Offset.zero);
-    expect(parseViewBox(svgWithViewBoxAndWidthHeight.attributes)!.viewBoxRect,
+    expect(parseViewBox(svgWithViewBox.attributes.toAttributeMap())!.viewBoxRect, rect);
+    expect(parseViewBox(svgWithViewBox.attributes.toAttributeMap())!.viewBoxOffset, Offset.zero);
+    expect(parseViewBox(svgWithViewBoxAndWidthHeight.attributes.toAttributeMap())!.viewBoxRect,
         rect);
-    expect(parseViewBox(svgWithWidthHeight.attributes)!.viewBoxRect, rect);
-    expect(parseViewBox(svgWithNoSizeInfo.attributes, nullOk: true), null);
-    expect(() => parseViewBox(svgWithNoSizeInfo.attributes), throwsStateError);
-    expect(parseViewBox(svgWithViewBoxMinXMinY.attributes)!.viewBoxRect, rect);
-    expect(parseViewBox(svgWithViewBoxMinXMinY.attributes)!.viewBoxOffset,
+    expect(parseViewBox(svgWithWidthHeight.attributes.toAttributeMap())!.viewBoxRect, rect);
+    expect(parseViewBox(svgWithNoSizeInfo.attributes.toAttributeMap(), nullOk: true), null);
+    expect(() => parseViewBox(svgWithNoSizeInfo.attributes.toAttributeMap()), throwsStateError);
+    expect(parseViewBox(svgWithViewBoxMinXMinY.attributes.toAttributeMap())!.viewBoxRect, rect);
+    expect(parseViewBox(svgWithViewBoxMinXMinY.attributes.toAttributeMap())!.viewBoxOffset,
         const Offset(-42.0, -56.0));
   });
 
@@ -107,12 +108,12 @@ void main() {
     final XmlStartElementEvent none =
         parseEvents('<linearGradient />').first as XmlStartElementEvent;
 
-    expect(parseTileMode(pad.attributes), TileMode.clamp);
-    expect(parseTileMode(invalid.attributes), TileMode.clamp);
-    expect(parseTileMode(none.attributes), TileMode.clamp);
+    expect(parseTileMode(pad.attributes.toAttributeMap()), TileMode.clamp);
+    expect(parseTileMode(invalid.attributes.toAttributeMap()), TileMode.clamp);
+    expect(parseTileMode(none.attributes.toAttributeMap()), TileMode.clamp);
 
-    expect(parseTileMode(reflect.attributes), TileMode.mirror);
-    expect(parseTileMode(repeat.attributes), TileMode.repeated);
+    expect(parseTileMode(reflect.attributes.toAttributeMap()), TileMode.mirror);
+    expect(parseTileMode(repeat.attributes.toAttributeMap()), TileMode.repeated);
   });
 
   test('@stroke-dashoffset tests', () {
@@ -124,8 +125,8 @@ void main() {
             as XmlStartElementEvent;
 
     // TODO(dnfield): DashOffset is completely opaque right now, maybe expose the raw value?
-    expect(parseDashOffset(abs.attributes), isNotNull);
-    expect(parseDashOffset(pct.attributes), isNotNull);
+    expect(parseDashOffset(abs.attributes.toAttributeMap()), isNotNull);
+    expect(parseDashOffset(pct.attributes.toAttributeMap()), isNotNull);
   });
 
   test('font-weight tests', () {

--- a/test/xml_svg_test.dart
+++ b/test/xml_svg_test.dart
@@ -27,7 +27,7 @@ void main() {
                 'style="stroke-opacity:1;fill-opacity:.23" />')
             .first as XmlStartElementEvent;
 
-    final attributes = el.attributes.toAttributeMap();
+    final Map<String, String> attributes = el.attributes.toAttributeMap();
     expect(getAttribute(attributes, 'stroke'), '#fff');
     expect(getAttribute(attributes, 'fill'), '#eee');
     expect(getAttribute(attributes, 'stroke-dashpattern'), '1 2');


### PR DESCRIPTION
The previous code used to iterate through a list of XmlEventAttributes for every call to getAttribute. The newer code constructs a Map, and looks up the attribute name directly.

This seems to show a 30% overall reduction to svg parsing costs.