### PR TITLE
Adopt `pkg:flutter_lints`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:flutter_lints/flutter.yaml
 # Specify analysis options.
 #
 # Until there are meta linter rules, each desired lint must be explicitly enabled.

--- a/lib/avd.dart
+++ b/lib/avd.dart
@@ -164,22 +164,22 @@ class AvdPicture extends SvgPicture {
       color == null ? null : ColorFilter.mode(color, colorBlendMode);
 
   /// A [PictureInfoDecoder] for [Uint8List]s that will clip to the viewBox.
-  static final PictureInfoDecoder<Uint8List> avdByteDecoder =
-      (Uint8List bytes, ColorFilter? colorFilter, String key) =>
-          avd.avdPictureDecoder(bytes, false, colorFilter, key);
+  static Future<PictureInfo> avdByteDecoder(
+          Uint8List bytes, ColorFilter? colorFilter, String key) =>
+      avd.avdPictureDecoder(bytes, false, colorFilter, key);
 
   /// A [PictureInfoDecoder] for strings that will clip to the viewBox.
-  static final PictureInfoDecoder<String> avdStringDecoder =
-      (String data, ColorFilter? colorFilter, String key) =>
-          avd.avdPictureStringDecoder(data, false, colorFilter, key);
+  static Future<PictureInfo> avdStringDecoder(
+          String data, ColorFilter? colorFilter, String key) =>
+      avd.avdPictureStringDecoder(data, false, colorFilter, key);
 
   /// A [PictureInfoDecoder] for [Uint8List]s that will not clip to the viewBox.
-  static final PictureInfoDecoder<Uint8List> avdByteDecoderOutsideViewBox =
-      (Uint8List bytes, ColorFilter? colorFilter, String key) =>
-          avd.avdPictureDecoder(bytes, true, colorFilter, key);
+  static Future<PictureInfo> avdByteDecoderOutsideViewBox(
+          Uint8List bytes, ColorFilter? colorFilter, String key) =>
+      avd.avdPictureDecoder(bytes, true, colorFilter, key);
 
   /// A [PictureInfoDecoder] for [String]s that will not clip to the viewBox.
-  static final PictureInfoDecoder<String> avdStringDecoderOutsideViewBox =
-      (String data, ColorFilter? colorFilter, String key) =>
-          avd.avdPictureStringDecoder(data, true, colorFilter, key);
+  static Future<PictureInfo> avdStringDecoderOutsideViewBox(
+          String data, ColorFilter? colorFilter, String key) =>
+      avd.avdPictureStringDecoder(data, true, colorFilter, key);
 }

--- a/lib/src/picture_cache.dart
+++ b/lib/src/picture_cache.dart
@@ -52,7 +52,7 @@ class PictureCache {
   ///
   /// The arguments must not be null. The `loader` cannot return null.
   PictureStreamCompleter putIfAbsent(
-      Object key, PictureStreamCompleter loader()) {
+      Object key, PictureStreamCompleter Function() loader) {
     assert(key != null); // ignore: unnecessary_null_comparison
     assert(loader != null); // ignore: unnecessary_null_comparison
     PictureStreamCompleter? result = _cache[key];
@@ -61,8 +61,9 @@ class PictureCache {
       // and thus move it to the end of the list.
       _cache.remove(key);
     } else {
-      if (_cache.length == maximumSize && maximumSize > 0)
+      if (_cache.length == maximumSize && maximumSize > 0) {
         _cache.remove(_cache.keys.first);
+      }
       result = loader();
     }
     if (maximumSize > 0) {

--- a/lib/src/picture_stream.dart
+++ b/lib/src/picture_stream.dart
@@ -162,7 +162,7 @@ class PictureStream with Diagnosticable {
   /// will go from being different than other [PictureStream]'s keys to
   /// potentially being the same as others'. No notification is sent when this
   /// happens.
-  Object? get key => _completer != null ? _completer : this;
+  Object? get key => _completer ?? this;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -94,8 +94,9 @@ Matrix4? parseTransform(String? transform) {
     return null;
   }
 
-  if (!_transformValidator.hasMatch(transform))
+  if (!_transformValidator.hasMatch(transform)) {
     throw StateError('illegal or unsupported transform: $transform');
+  }
   final Iterable<Match> matches =
       _transformCommand.allMatches(transform).toList().reversed;
   Matrix4 result = Matrix4.identity();
@@ -199,12 +200,11 @@ final RegExp _whitespacePattern = RegExp(r'\s');
 Future<Image> resolveImage(String href) async {
   assert(href != '');
 
-  final Future<Image> Function(Uint8List) decodeImage =
-      (Uint8List bytes) async {
+  Future<Image> decodeImage(Uint8List bytes) async {
     final Codec codec = await instantiateImageCodec(bytes);
     final FrameInfo frame = await codec.getNextFrame();
     return frame.image;
-  };
+  }
 
   if (href.startsWith('http')) {
     final Uint8List bytes = await httpGet(href);
@@ -227,7 +227,7 @@ const ParagraphConstraints _infiniteParagraphConstraints = ParagraphConstraints(
 
 /// A [DrawablePaint] with a transparent stroke.
 const DrawablePaint transparentStroke =
-    DrawablePaint(PaintingStyle.stroke, color: Color(0x0));
+    DrawablePaint(PaintingStyle.stroke, color: Color(0x00000000));
 
 /// Creates a [Paragraph] object using the specified [text], [style], and
 /// [foregroundOverride].

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -586,7 +586,7 @@ class DrawableDefinitionServer {
     assert(id != null); // ignore: unnecessary_null_comparison
     assert(bounds != null); // ignore: unnecessary_null_comparison
     final DrawableGradient? srv = _gradients[id];
-    return srv != null ? srv.createShader(bounds) : null;
+    return srv?.createShader(bounds);
   }
 
   /// Retreive a gradient from the pre-defined [DrawableGradient] collection.
@@ -1003,7 +1003,7 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
       return;
     }
 
-    final Function innerDraw = () {
+    void innerDraw() {
       if (style!.groupOpacity == 0) {
         return;
       }
@@ -1042,7 +1042,7 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
       if (transform != null) {
         canvas.restore();
       }
-    };
+    }
 
     if (style?.clipPath?.isNotEmpty == true) {
       for (Path clipPath in style!.clipPath!) {
@@ -1225,7 +1225,7 @@ class DrawableShape implements DrawableStyleable {
 
     path.fillType = style.pathFillType ?? PathFillType.nonZero;
     // if we have multiple clips to apply, need to wrap this in a loop.
-    final Function innerDraw = () {
+    void innerDraw() {
       if (transform != null) {
         canvas.save();
         canvas.transform(transform!);
@@ -1270,7 +1270,7 @@ class DrawableShape implements DrawableStyleable {
       if (transform != null) {
         canvas.restore();
       }
-    };
+    }
 
     if (style.clipPath?.isNotEmpty == true) {
       for (Path clip in style.clipPath!) {

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -554,31 +554,31 @@ class SvgPicture extends StatefulWidget {
 
   /// The default placeholder for a SVG that may take time to parse or
   /// retrieve, e.g. from a network location.
-  static WidgetBuilder defaultPlaceholderBuilder =
-      (BuildContext ctx) => const LimitedBox();
+  static Widget defaultPlaceholderBuilder(BuildContext ctx) =>
+      const LimitedBox();
 
   static ColorFilter? _getColorFilter(Color? color, BlendMode colorBlendMode) =>
       color == null ? null : ColorFilter.mode(color, colorBlendMode);
 
   /// A [PictureInfoDecoder] for [Uint8List]s that will clip to the viewBox.
-  static final PictureInfoDecoder<Uint8List> svgByteDecoder =
-      (Uint8List bytes, ColorFilter? colorFilter, String key) =>
-          svg.svgPictureDecoder(bytes, false, colorFilter, key);
+  static Future<PictureInfo> svgByteDecoder(
+          Uint8List bytes, ColorFilter? colorFilter, String key) =>
+      svg.svgPictureDecoder(bytes, false, colorFilter, key);
 
   /// A [PictureInfoDecoder] for strings that will clip to the viewBox.
-  static final PictureInfoDecoder<String> svgStringDecoder =
-      (String data, ColorFilter? colorFilter, String key) =>
-          svg.svgPictureStringDecoder(data, false, colorFilter, key);
+  static Future<PictureInfo> svgStringDecoder(
+          String data, ColorFilter? colorFilter, String key) =>
+      svg.svgPictureStringDecoder(data, false, colorFilter, key);
 
   /// A [PictureInfoDecoder] for [Uint8List]s that will not clip to the viewBox.
-  static final PictureInfoDecoder<Uint8List> svgByteDecoderOutsideViewBox =
-      (Uint8List bytes, ColorFilter? colorFilter, String key) =>
-          svg.svgPictureDecoder(bytes, true, colorFilter, key);
+  static Future<PictureInfo> svgByteDecoderOutsideViewBox(
+          Uint8List bytes, ColorFilter? colorFilter, String key) =>
+      svg.svgPictureDecoder(bytes, true, colorFilter, key);
 
   /// A [PictureInfoDecoder] for [String]s that will not clip to the viewBox.
-  static final PictureInfoDecoder<String> svgStringDecoderOutsideViewBox =
-      (String data, ColorFilter? colorFilter, String key) =>
-          svg.svgPictureStringDecoder(data, true, colorFilter, key);
+  static Future<PictureInfo> svgStringDecoderOutsideViewBox(
+          String data, ColorFilter? colorFilter, String key) =>
+      svg.svgPictureStringDecoder(data, true, colorFilter, key);
 
   /// If specified, the width to use for the SVG.  If unspecified, the SVG
   /// will take the width of its parent.
@@ -720,8 +720,9 @@ class _SvgPictureState extends State<SvgPicture> {
       return;
     }
 
-    if (_isListeningToStream)
+    if (_isListeningToStream) {
       _pictureStream!.removeListener(_handleImageChanged);
+    }
 
     _pictureStream = newStream;
     if (_isListeningToStream) {
@@ -803,7 +804,7 @@ class _SvgPictureState extends State<SvgPicture> {
       child = Semantics(
         container: widget.semanticsLabel != null,
         image: true,
-        label: widget.semanticsLabel == null ? '' : widget.semanticsLabel,
+        label: widget.semanticsLabel ?? '',
         child: child,
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   xml: ^5.0.0
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   path: ^1.8.0

--- a/test/picture_cache_test.dart
+++ b/test/picture_cache_test.dart
@@ -74,7 +74,7 @@ void main() {
 
     expect(PictureProvider.cache.count, 0);
     await precachePicture(
-      StringPicture(
+      const StringPicture(
         SvgPicture.svgStringDecoder,
         svgString,
       ),
@@ -109,7 +109,7 @@ void main() {
 
     expect(PictureProvider.cache.count, 0);
     await precachePicture(
-      StringPicture(
+      const StringPicture(
         SvgPicture.svgStringDecoder,
         svgString,
       ),
@@ -134,7 +134,7 @@ void main() {
     }
 
     await precachePicture(
-      StringPicture(
+      const StringPicture(
         SvgPicture.svgStringDecoder,
         svgString,
       ),


### PR DESCRIPTION
Hey Dan,

Are you up for adopting pkg:flutter_lints? I've done a first pass at making the package conform, but there is additional work required in trimming now redundant rules listed in the `analysis_options.yaml` and thinking about whether to drop the various `print` statements.

Let me know what you think,

brett