### PR TITLE
Unused parameter `bounds` of method draw()

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ svgRoot.scaleCanvasToViewBox(canvas);
 // Optional, but probably normally desireable: ensure the SVG isn't rendered
 // outside of the viewbox bounds
 svgRoot.clipCanvasToViewBox(canvas);
-svgRoot.draw(canvas, size);
+// The second parameter is not used
+svgRoot.draw(canvas, null);
 ```
 
 The `SvgPicture` helps to automate this logic, and it provides some convenience

--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -63,7 +63,7 @@ String _getAttribute(
 extension AttributeMapXmlEventAttributeExtension on List<XmlEventAttribute> {
   /// Converts the List<XmlEventAttribute> to an attribute map.
   Map<String, String> toAttributeMap() => <String, String>{
-    for (final XmlEventAttribute attribute in this)
-      attribute.localName: attribute.value.trim(),
-  };
+        for (final XmlEventAttribute attribute in this)
+          attribute.localName: attribute.value.trim(),
+      };
 }

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -885,8 +885,12 @@ class DrawableRoot implements DrawableParent {
   bool get hasDrawableContent =>
       children.isNotEmpty == true && !viewport.viewBox.isEmpty;
 
+  /// Draws the contents or children of this [Drawable] to the `canvas`, using
+  /// the `parentPaint` to optionally override the child's paint.
+  ///
+  /// The `_` is not used.
   @override
-  void draw(Canvas canvas, Rect bounds) {
+  void draw(Canvas canvas, _) {
     if (!hasDrawableContent) {
       return;
     }

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -888,9 +888,9 @@ class DrawableRoot implements DrawableParent {
   /// Draws the contents or children of this [Drawable] to the `canvas`, using
   /// the `parentPaint` to optionally override the child's paint.
   ///
-  /// The `_` is not used.
+  /// The `bounds` is not used.
   @override
-  void draw(Canvas canvas, _) {
+  void draw(Canvas canvas, Rect bounds) {
     if (!hasDrawableContent) {
       return;
     }


### PR DESCRIPTION
I think programmers should be aware that this parameter is not used