### PR TITLE
Add support for `currentColor` to `SvgPicture`

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1,11 +1,12 @@
 import 'package:xml/xml_events.dart' as xml show parseEvents;
 
 import 'src/svg/parser_state.dart';
+import 'src/svg/theme.dart';
 import 'src/vector_drawable.dart';
 
 /// Parses SVG data into a [DrawableRoot].
 class SvgParser {
-  /// Parses SVG from a string to a [DrawableRoot].
+  /// Parses SVG from a string to a [DrawableRoot] with the provided [theme].
   ///
   /// The [key] parameter is used for debugging purposes.
   ///
@@ -17,11 +18,12 @@ class SvgParser {
   /// Defaults to false.
   Future<DrawableRoot> parse(
     String str, {
+    SvgTheme? theme,
     String? key,
     bool warningsAsErrors = false,
   }) async {
     final SvgParserState state =
-        SvgParserState(xml.parseEvents(str), key, warningsAsErrors);
+        SvgParserState(xml.parseEvents(str), theme, key, warningsAsErrors);
     return await state.parse();
   }
 }

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -323,6 +323,8 @@ abstract class PictureProvider<T> {
   final ColorFilter? colorFilter;
 
   /// The default color applied to SVG elements that inherit the color property.
+  @visibleForTesting
+  Color? get currentColor => _currentColor;
   Color? _currentColor;
 
   /// Sets the [_currentColor] to [color].

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -201,6 +201,24 @@ class PictureConfiguration {
   }
 }
 
+/// A type of the [PictureProvider].
+enum PictureProviderType {
+  /// Refers to the provider of type [ExactAssetPicture].
+  asset,
+
+  /// Refers to the provider of type [NetworkPicture].
+  network,
+
+  /// Refers to the provider of type [FilePicture].
+  file,
+
+  /// Refers to the provider of type [MemoryPicture].
+  memory,
+
+  /// Refers to the provider of type [StringPicture].
+  string,
+}
+
 /// Identifies a picture without committing to the precise final asset. This
 /// allows a set of pictures to be identified and for the precise picture to later
 /// be resolved based on the environment, e.g. the device pixel ratio.

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -447,19 +447,20 @@ abstract class AssetBundlePictureProvider
   /// const constructors so that they can be used in const expressions.
   AssetBundlePictureProvider(this.decoderBuilder, ColorFilter? colorFilter)
       : assert(decoderBuilder != null), // ignore: unnecessary_null_comparison
-        _decoder = decoderBuilder(null),
+        decoder = decoderBuilder(null),
         super(colorFilter);
 
-  /// The decoder builder to build a [_decoder] when [currentColor] changes.
+  /// The decoder builder to build a [decoder] when [currentColor] changes.
   final PictureInfoDecoderBuilder<String> decoderBuilder;
 
   /// The decoder to use to turn a string into a [PictureInfo] object.
-  PictureInfoDecoder<String> _decoder;
+  @visibleForTesting
+  PictureInfoDecoder<String> decoder;
 
   @override
   set currentColor(Color? color) {
     _currentColor = color;
-    _decoder = decoderBuilder(_currentColor);
+    decoder = decoderBuilder(_currentColor);
   }
 
   /// Converts a key into an [PictureStreamCompleter], and begins fetching the
@@ -483,7 +484,7 @@ abstract class AssetBundlePictureProvider
       AssetBundlePictureKey key, PictureErrorListener? onError) async {
     final String data = await key.bundle.loadString(key.name);
     if (onError != null) {
-      return _decoder(
+      return decoder(
         data,
         key.colorFilter,
         key.toString(),
@@ -492,7 +493,7 @@ abstract class AssetBundlePictureProvider
         return Future<PictureInfo>.error(error, stack);
       });
     }
-    return _decoder(data, key.colorFilter, key.toString());
+    return decoder(data, key.colorFilter, key.toString());
   }
 }
 
@@ -513,14 +514,15 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
   NetworkPicture(this.decoderBuilder, this.url,
       {this.headers, ColorFilter? colorFilter})
       : assert(url != null), // ignore: unnecessary_null_comparison
-        _decoder = decoderBuilder(null),
+        decoder = decoderBuilder(null),
         super(colorFilter);
 
-  /// The decoder builder to build a [_decoder] when [currentColor] changes.
+  /// The decoder builder to build a [decoder] when [currentColor] changes.
   final PictureInfoDecoderBuilder<Uint8List> decoderBuilder;
 
   /// The decoder to use to turn a [Uint8List] into a [PictureInfo] object.
-  PictureInfoDecoder<Uint8List> _decoder;
+  @visibleForTesting
+  PictureInfoDecoder<Uint8List> decoder;
 
   /// The URL from which the picture will be fetched.
   final String url;
@@ -531,7 +533,7 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
   @override
   set currentColor(Color? color) {
     _currentColor = color;
-    _decoder = decoderBuilder(_currentColor);
+    decoder = decoderBuilder(_currentColor);
   }
 
   @override
@@ -555,7 +557,7 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
     final Uint8List bytes = await httpGet(url, headers: headers);
 
     if (onError != null) {
-      return _decoder(
+      return decoder(
         bytes,
         colorFilter,
         key.toString(),
@@ -564,7 +566,7 @@ class NetworkPicture extends PictureProvider<NetworkPicture> {
         return Future<PictureInfo>.error(error, stack);
       });
     }
-    return _decoder(bytes, colorFilter, key.toString());
+    return decoder(bytes, colorFilter, key.toString());
   }
 
   @override
@@ -598,22 +600,23 @@ class FilePicture extends PictureProvider<FilePicture> {
   FilePicture(this.decoderBuilder, this.file, {ColorFilter? colorFilter})
       : assert(decoderBuilder != null), // ignore: unnecessary_null_comparison
         assert(file != null), // ignore: unnecessary_null_comparison
-        _decoder = decoderBuilder(null),
+        decoder = decoderBuilder(null),
         super(colorFilter);
 
   /// The file to decode into a picture.
   final File file;
 
-  /// The decoder builder to build a [_decoder] when [currentColor] changes.
+  /// The decoder builder to build a [decoder] when [currentColor] changes.
   final PictureInfoDecoderBuilder<Uint8List> decoderBuilder;
 
   /// The [PictureInfoDecoder] to use for loading this picture.
-  PictureInfoDecoder<Uint8List> _decoder;
+  @visibleForTesting
+  PictureInfoDecoder<Uint8List> decoder;
 
   @override
   set currentColor(Color? color) {
     _currentColor = color;
-    _decoder = decoderBuilder(_currentColor);
+    decoder = decoderBuilder(_currentColor);
   }
 
   @override
@@ -639,7 +642,7 @@ class FilePicture extends PictureProvider<FilePicture> {
       return null;
     }
     if (onError != null) {
-      return _decoder(
+      return decoder(
         data,
         colorFilter,
         key.toString(),
@@ -648,7 +651,7 @@ class FilePicture extends PictureProvider<FilePicture> {
         return Future<PictureInfo>.error(error, stack);
       });
     }
-    return _decoder(data, colorFilter, key.toString());
+    return decoder(data, colorFilter, key.toString());
   }
 
   @override
@@ -687,14 +690,15 @@ class MemoryPicture extends PictureProvider<MemoryPicture> {
   /// The arguments must not be null.
   MemoryPicture(this.decoderBuilder, this.bytes, {ColorFilter? colorFilter})
       : assert(bytes != null), // ignore: unnecessary_null_comparison
-        _decoder = decoderBuilder(null),
+        decoder = decoderBuilder(null),
         super(colorFilter);
 
-  /// The decoder builder to build a [_decoder] when [currentColor] changes.
+  /// The decoder builder to build a [decoder] when [currentColor] changes.
   final PictureInfoDecoderBuilder<Uint8List> decoderBuilder;
 
   /// The [PictureInfoDecoder] to use when drawing this picture.
-  PictureInfoDecoder<Uint8List> _decoder;
+  @visibleForTesting
+  PictureInfoDecoder<Uint8List> decoder;
 
   /// The bytes to decode into a picture.
   final Uint8List bytes;
@@ -702,7 +706,7 @@ class MemoryPicture extends PictureProvider<MemoryPicture> {
   @override
   set currentColor(Color? color) {
     _currentColor = color;
-    _decoder = decoderBuilder(_currentColor);
+    decoder = decoderBuilder(_currentColor);
   }
 
   @override
@@ -720,7 +724,7 @@ class MemoryPicture extends PictureProvider<MemoryPicture> {
       {PictureErrorListener? onError}) async {
     assert(key == this);
     if (onError != null) {
-      return _decoder(
+      return decoder(
         bytes,
         colorFilter,
         key.toString(),
@@ -729,7 +733,7 @@ class MemoryPicture extends PictureProvider<MemoryPicture> {
         return Future<PictureInfo>.error(error, stack);
       });
     }
-    return _decoder(bytes, colorFilter, key.toString());
+    return decoder(bytes, colorFilter, key.toString());
   }
 
   @override
@@ -767,14 +771,15 @@ class StringPicture extends PictureProvider<StringPicture> {
   /// The arguments must not be null.
   StringPicture(this.decoderBuilder, this.string, {ColorFilter? colorFilter})
       : assert(string != null), // ignore: unnecessary_null_comparison
-        _decoder = decoderBuilder(null),
+        decoder = decoderBuilder(null),
         super(colorFilter);
 
-  /// The decoder builder to build a [_decoder] when [currentColor] changes.
+  /// The decoder builder to build a [decoder] when [currentColor] changes.
   final PictureInfoDecoderBuilder<String> decoderBuilder;
 
   /// The [PictureInfoDecoder] to use for decoding this picture.
-  PictureInfoDecoder<String> _decoder;
+  @visibleForTesting
+  PictureInfoDecoder<String> decoder;
 
   /// The string to decode into a picture.
   final String string;
@@ -782,7 +787,7 @@ class StringPicture extends PictureProvider<StringPicture> {
   @override
   set currentColor(Color? color) {
     _currentColor = color;
-    _decoder = decoderBuilder(_currentColor);
+    decoder = decoderBuilder(_currentColor);
   }
 
   @override
@@ -802,7 +807,7 @@ class StringPicture extends PictureProvider<StringPicture> {
   }) {
     assert(key == this);
     if (onError != null) {
-      return _decoder(
+      return decoder(
         string,
         colorFilter,
         key.toString(),
@@ -811,7 +816,7 @@ class StringPicture extends PictureProvider<StringPicture> {
         return Future<PictureInfo>.error(error, stack);
       });
     }
-    return _decoder(string, colorFilter, key.toString());
+    return decoder(string, colorFilter, key.toString());
   }
 
   @override

--- a/lib/src/picture_provider.dart
+++ b/lib/src/picture_provider.dart
@@ -207,24 +207,6 @@ class PictureConfiguration {
   }
 }
 
-/// A type of the [PictureProvider].
-enum PictureProviderType {
-  /// Refers to the provider of type [ExactAssetPicture].
-  asset,
-
-  /// Refers to the provider of type [NetworkPicture].
-  network,
-
-  /// Refers to the provider of type [FilePicture].
-  file,
-
-  /// Refers to the provider of type [MemoryPicture].
-  memory,
-
-  /// Refers to the provider of type [StringPicture].
-  string,
-}
-
 /// Identifies a picture without committing to the precise final asset. This
 /// allows a set of pictures to be identified and for the precise picture to later
 /// be resolved based on the environment, e.g. the device pixel ratio.

--- a/lib/src/svg/default_theme.dart
+++ b/lib/src/svg/default_theme.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/src/svg/theme.dart';
+
+/// The SVG theme to apply to descendant [SvgPicture] widgets
+/// which don't have explicit theme values.
+class DefaultSvgTheme extends InheritedTheme {
+  /// Creates a default SVG theme for the given subtree
+  /// using the provided [theme].
+  const DefaultSvgTheme({
+    Key? key,
+    required Widget child,
+    required this.theme,
+  }) : super(key: key, child: child);
+
+  /// The SVG theme to apply.
+  final SvgTheme theme;
+
+  /// The closest instance of this class that encloses the given context.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// DefaultSvgTheme theme = DefaultSvgTheme.of(context);
+  /// ```
+  static DefaultSvgTheme? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DefaultSvgTheme>();
+  }
+
+  @override
+  bool updateShouldNotify(DefaultSvgTheme oldWidget) {
+    return theme != oldWidget.theme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return DefaultSvgTheme(
+      theme: theme,
+      child: child,
+    );
+  }
+}

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -103,6 +103,7 @@ class _Elements {
         library: 'SVG',
         context: ErrorDescription('in _Element.svg'),
       ));
+
       parserState._parentDrawables.addLast(
         _SvgGroupTuple(
           'svg',
@@ -151,7 +152,6 @@ class _Elements {
         parserState._definitions,
         parserState.rootBounds,
         parent.style,
-        currentColor: parserState.theme?.currentColor,
       ),
       transform: parseTransform(parserState.attribute('transform'))?.storage,
     );
@@ -174,7 +174,6 @@ class _Elements {
         parserState._definitions,
         null,
         parent.style,
-        currentColor: parserState.theme?.currentColor,
       ),
       transform: parseTransform(parserState.attribute('transform'))?.storage,
     );
@@ -195,7 +194,6 @@ class _Elements {
       parserState._definitions,
       parserState.rootBounds,
       parent!.style,
-      currentColor: parserState.theme?.currentColor,
     );
 
     final Matrix4 transform =
@@ -535,7 +533,6 @@ class _Elements {
         parserState._definitions,
         parserState.rootBounds,
         parentStyle,
-        currentColor: parserState.theme?.currentColor,
       ),
       size: size,
       transform: parseTransform(parserState.attribute('transform'))?.storage,
@@ -618,7 +615,6 @@ class _Elements {
           parserState._definitions,
           parserState.rootBounds,
           lastTextInfo?.style ?? parserState.currentGroup!.style,
-          currentColor: parserState.theme?.currentColor,
         ),
         currentOffset,
         transform,
@@ -909,7 +905,6 @@ class SvgParserState {
         path.getBounds(),
         parentStyle,
         defaultFillColor: colorBlack,
-        currentColor: theme?.currentColor,
       ),
       transform: parseTransform(getAttribute(attributes, 'transform'))?.storage,
     );

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -6,6 +6,7 @@ import 'package:path_drawing/path_drawing.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'package:xml/xml_events.dart' hide parseEvents;
 
+import '../svg/theme.dart';
 import '../utilities/errors.dart';
 import '../utilities/numbers.dart';
 import '../utilities/xml.dart';
@@ -114,6 +115,7 @@ class _Elements {
               parserState._definitions,
               viewBox!.viewBoxRect,
               null,
+              currentColor: parserState.theme?.currentColor,
             ),
           ),
         ),
@@ -131,6 +133,7 @@ class _Elements {
         parserState._definitions,
         viewBox.viewBoxRect,
         null,
+        currentColor: parserState.theme?.currentColor,
       ),
     );
     parserState.addGroup(parserState._currentStartElement!, parserState._root);
@@ -148,6 +151,7 @@ class _Elements {
         parserState._definitions,
         parserState.rootBounds,
         parent.style,
+        currentColor: parserState.theme?.currentColor,
       ),
       transform: parseTransform(parserState.attribute('transform'))?.storage,
     );
@@ -170,6 +174,7 @@ class _Elements {
         parserState._definitions,
         null,
         parent.style,
+        currentColor: parserState.theme?.currentColor,
       ),
       transform: parseTransform(parserState.attribute('transform'))?.storage,
     );
@@ -190,6 +195,7 @@ class _Elements {
       parserState._definitions,
       parserState.rootBounds,
       parent!.style,
+      currentColor: parserState.theme?.currentColor,
     );
 
     final Matrix4 transform =
@@ -529,6 +535,7 @@ class _Elements {
         parserState._definitions,
         parserState.rootBounds,
         parentStyle,
+        currentColor: parserState.theme?.currentColor,
       ),
       size: size,
       transform: parseTransform(parserState.attribute('transform'))?.storage,
@@ -611,6 +618,7 @@ class _Elements {
           parserState._definitions,
           parserState.rootBounds,
           lastTextInfo?.style ?? parserState.currentGroup!.style,
+          currentColor: parserState.theme?.currentColor,
         ),
         currentOffset,
         transform,
@@ -731,10 +739,18 @@ class _SvgGroupTuple {
 /// Maintains state while pushing an [XmlPushReader] through the SVG tree.
 class SvgParserState {
   /// Creates a new [SvgParserState].
-  SvgParserState(Iterable<XmlEvent> events, this._key, this._warningsAsErrors)
-      // ignore: unnecessary_null_comparison
-      : assert(events != null),
+  SvgParserState(
+    Iterable<XmlEvent> events,
+    this.theme,
+    this._key,
+    this._warningsAsErrors,
+  )   
+  // ignore: unnecessary_null_comparison
+  : assert(events != null),
         _eventIterator = events.iterator;
+
+  /// A theme used when parsing SVG elements.
+  final SvgTheme? theme;
 
   final Iterator<XmlEvent> _eventIterator;
   final String? _key;
@@ -893,6 +909,7 @@ class SvgParserState {
         path.getBounds(),
         parentStyle,
         defaultFillColor: colorBlack,
+        currentColor: theme?.currentColor,
       ),
       transform: parseTransform(getAttribute(attributes, 'transform'))?.storage,
     );

--- a/lib/src/svg/theme.dart
+++ b/lib/src/svg/theme.dart
@@ -1,0 +1,30 @@
+import 'dart:ui';
+
+/// A theme used when decoding an SVG picture.
+class SvgTheme {
+  /// Instantiates an SVG theme with the [colorFilter] and [currentColor].
+  const SvgTheme({
+    this.colorFilter,
+    this.currentColor,
+  });
+
+  /// The color filter, if any, to apply to this widget.
+  final ColorFilter? colorFilter;
+
+  /// The default color applied to SVG elements that inherit the color property.
+  /// See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword
+  final Color? currentColor;
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is SvgTheme &&
+        colorFilter == other.colorFilter &&
+        currentColor == other.currentColor;
+  }
+
+  @override
+  int get hashCode => hashValues(colorFilter, currentColor);
+}

--- a/lib/src/svg/theme.dart
+++ b/lib/src/svg/theme.dart
@@ -2,14 +2,10 @@ import 'dart:ui';
 
 /// A theme used when decoding an SVG picture.
 class SvgTheme {
-  /// Instantiates an SVG theme with the [colorFilter] and [currentColor].
+  /// Instantiates an SVG theme with the [currentColor].
   const SvgTheme({
-    this.colorFilter,
     this.currentColor,
   });
-
-  /// The color filter, if any, to apply to this widget.
-  final ColorFilter? colorFilter;
 
   /// The default color applied to SVG elements that inherit the color property.
   /// See: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword
@@ -20,11 +16,9 @@ class SvgTheme {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is SvgTheme &&
-        colorFilter == other.colorFilter &&
-        currentColor == other.currentColor;
+    return other is SvgTheme && currentColor == other.currentColor;
   }
 
   @override
-  int get hashCode => hashValues(colorFilter, currentColor);
+  int get hashCode => currentColor.hashCode;
 }

--- a/lib/src/svg/xml_parsers.dart
+++ b/lib/src/svg/xml_parsers.dart
@@ -178,6 +178,7 @@ DrawablePaint? parseStroke(
   Rect? bounds,
   DrawableDefinitionServer definitions,
   DrawablePaint? parentStroke,
+  Color? currentColor,
 ) {
   final String rawStroke = getAttribute(attributes, 'stroke')!;
   final String? rawStrokeOpacity = getAttribute(
@@ -217,7 +218,10 @@ DrawablePaint? parseStroke(
     PaintingStyle.stroke,
     color: rawStroke == ''
         ? (parentStroke?.color ?? colorBlack).withOpacity(opacity)
-        : (parseColor(rawStroke) ?? parentStroke?.color ?? colorBlack)
+        : (parseColor(rawStroke) ??
+                currentColor ??
+                parentStroke?.color ??
+                colorBlack)
             .withOpacity(opacity),
     strokeCap: rawStrokeCap == 'null'
         ? parentStroke?.strokeCap ?? StrokeCap.butt
@@ -249,6 +253,7 @@ DrawablePaint? parseFill(
   DrawableDefinitionServer definitions,
   DrawablePaint? parentFill,
   Color? defaultFillColor,
+  Color? currentColor,
 ) {
   final String rawFill = getAttribute(el, 'fill')!;
   final String? rawFillOpacity = getAttribute(el, 'fill-opacity', def: '1.0');
@@ -284,6 +289,7 @@ DrawablePaint? parseFill(
       opacity,
       rawOpacity != '' || rawFillOpacity != '',
       defaultFillColor,
+      currentColor,
     ),
   );
 }
@@ -294,9 +300,13 @@ Color? _determineFillColor(
   double opacity,
   bool explicitOpacity,
   Color? defaultFillColor,
+  Color? currentColor,
 ) {
-  final Color? color =
-      parseColor(rawFill) ?? parentFillColor ?? defaultFillColor;
+  final Color? color = parseColor(rawFill) ??
+      currentColor ??
+      parentFillColor ??
+      defaultFillColor;
+
   if (explicitOpacity && color != null) {
     return color.withOpacity(opacity);
   }
@@ -465,6 +475,7 @@ DrawableStyle parseStyle(
   Rect? bounds,
   DrawableStyle? parentStyle, {
   Color? defaultFillColor,
+  Color? currentColor,
 }) {
   return DrawableStyle.mergeAndBlend(
     parentStyle,
@@ -474,6 +485,7 @@ DrawableStyle parseStyle(
       bounds,
       definitions,
       parentStyle?.stroke,
+      currentColor,
     ),
     dashArray: parseDashArray(attributes),
     dashOffset: parseDashOffset(attributes),
@@ -484,6 +496,7 @@ DrawableStyle parseStyle(
       definitions,
       parentStyle?.fill,
       defaultFillColor,
+      currentColor,
     ),
     pathFillType: parseFillRule(
       attributes,

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -55,6 +55,12 @@ abstract class DrawableParent implements DrawableStyleable {
   ///
   /// Each child may itself have children.
   List<Drawable>? get children;
+
+  /// The default color used to provide a potential indirect color value
+  /// for the `fill`, `stroke` and `stop-color` of descendant elements.
+  ///
+  /// See: https://www.w3.org/TR/SVG11/color.html#ColorProperty
+  Color? get color;
 }
 
 /// Styling information for vector drawing.
@@ -840,6 +846,7 @@ class DrawableRoot implements DrawableParent {
     this.definitions,
     this.style, {
     this.transform,
+    this.color,
   });
 
   /// The expected coordinates used by child paths for drawing.
@@ -850,6 +857,9 @@ class DrawableRoot implements DrawableParent {
 
   @override
   final Float64List? transform;
+
+  @override
+  final Color? color;
 
   @override
   final List<Drawable> children;
@@ -986,7 +996,13 @@ class DrawableRoot implements DrawableParent {
 /// `stroke`, or `fill`.
 class DrawableGroup implements DrawableStyleable, DrawableParent {
   /// Creates a new DrawableGroup.
-  const DrawableGroup(this.id, this.children, this.style, {this.transform});
+  const DrawableGroup(
+    this.id,
+    this.children,
+    this.style, {
+    this.transform,
+    this.color,
+  });
 
   @override
   final String? id;
@@ -997,6 +1013,8 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
   final DrawableStyle? style;
   @override
   final Float64List? transform;
+  @override
+  final Color? color;
 
   @override
   bool get hasDrawableContent => children != null && children!.isNotEmpty;

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -56,13 +56,14 @@ class Svg {
   Future<PictureInfo> svgPictureDecoder(
     Uint8List raw,
     bool allowDrawingOutsideOfViewBox,
+    ColorFilter? colorFilter,
     SvgTheme theme,
     String key,
   ) async {
     final DrawableRoot svgRoot = await fromSvgBytes(raw, theme, key);
     final Picture pic = svgRoot.toPicture(
       clipToViewBox: allowDrawingOutsideOfViewBox == true ? false : true,
-      colorFilter: theme.colorFilter,
+      colorFilter: colorFilter,
     );
     return PictureInfo(
       picture: pic,
@@ -84,6 +85,7 @@ class Svg {
   Future<PictureInfo> svgPictureStringDecoder(
     String raw,
     bool allowDrawingOutsideOfViewBox,
+    ColorFilter? colorFilter,
     SvgTheme theme,
     String key,
   ) async {
@@ -91,7 +93,7 @@ class Svg {
     return PictureInfo(
       picture: svg.toPicture(
         clipToViewBox: allowDrawingOutsideOfViewBox == true ? false : true,
-        colorFilter: theme.colorFilter,
+        colorFilter: colorFilter,
         size: svg.viewport.viewBox,
       ),
       viewport: svg.viewport.viewBoxRect,
@@ -606,7 +608,8 @@ class SvgPicture extends StatefulWidget {
               svg.svgPictureDecoder(
                 bytes,
                 false,
-                SvgTheme(colorFilter: colorFilter, currentColor: currentColor),
+                colorFilter,
+                SvgTheme(currentColor: currentColor),
                 key,
               );
 
@@ -617,7 +620,8 @@ class SvgPicture extends StatefulWidget {
               svg.svgPictureStringDecoder(
                 data,
                 false,
-                SvgTheme(colorFilter: colorFilter, currentColor: currentColor),
+                colorFilter,
+                SvgTheme(currentColor: currentColor),
                 key,
               );
 
@@ -628,7 +632,8 @@ class SvgPicture extends StatefulWidget {
               svg.svgPictureDecoder(
                 bytes,
                 true,
-                SvgTheme(colorFilter: colorFilter, currentColor: currentColor),
+                colorFilter,
+                SvgTheme(currentColor: currentColor),
                 key,
               );
 
@@ -639,7 +644,8 @@ class SvgPicture extends StatefulWidget {
               svg.svgPictureStringDecoder(
                 data,
                 true,
-                SvgTheme(colorFilter: colorFilter, currentColor: currentColor),
+                colorFilter,
+                SvgTheme(currentColor: currentColor),
                 key,
               );
 

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -134,7 +134,7 @@ class Svg {
     String key,
   ) async {
     final SvgParser parser = SvgParser();
-    return await parser.parse(rawSvg, key: key);
+    return await parser.parse(rawSvg, theme: theme, key: key);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mocktail: ^0.1.4
   path: ^1.8.0
   test: ^1.16.0
 

--- a/test/default_theme_test.dart
+++ b/test/default_theme_test.dart
@@ -1,0 +1,79 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'dart:ui';
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_svg/src/svg/default_theme.dart';
+import 'package:flutter_svg/src/svg/theme.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DefaultSvgTheme', () {
+    testWidgets('changes propagate to SvgPicture', (WidgetTester tester) async {
+      const SvgTheme svgTheme = SvgTheme(
+        currentColor: Color(0xFF733821),
+      );
+
+      final SvgPicture svgPictureWidget = SvgPicture.string('''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10" height="10" fill="currentColor" />
+</svg>''');
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: svgTheme,
+        child: svgPictureWidget,
+      ));
+
+      SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        svgPicture.pictureProvider.currentColor,
+        equals(svgTheme.currentColor),
+      );
+
+      const SvgTheme anotherSvgTheme = SvgTheme(
+        currentColor: Color(0xFF05290E),
+      );
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: anotherSvgTheme,
+        child: svgPictureWidget,
+      ));
+
+      svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        svgPicture.pictureProvider.currentColor,
+        equals(anotherSvgTheme.currentColor),
+      );
+    });
+
+    testWidgets(
+        'currentColor widget property takes precedence over '
+        'the theme from DefaultSvgTheme', (WidgetTester tester) async {
+      const SvgTheme svgTheme = SvgTheme(
+        currentColor: Color(0xFF733821),
+      );
+
+      final SvgPicture svgPictureWidget = SvgPicture.string(
+        '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10" height="10" fill="currentColor" />
+</svg>''',
+        currentColor: Color(0xFF05290E),
+      );
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: svgTheme,
+        child: svgPictureWidget,
+      ));
+
+      final SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        svgPicture.pictureProvider.currentColor,
+        equals(Color(0xFF05290E)),
+      );
+    });
+  });
+}

--- a/test/picture_cache_test.dart
+++ b/test/picture_cache_test.dart
@@ -75,7 +75,7 @@ void main() {
     expect(PictureProvider.cache.count, 0);
     await precachePicture(
       StringPicture(
-        SvgPicture.svgStringDecoderBuilder(null),
+        SvgPicture.svgStringDecoderBuilder,
         svgString,
       ),
       tester.element(find.text('test_text')),
@@ -110,7 +110,7 @@ void main() {
     expect(PictureProvider.cache.count, 0);
     await precachePicture(
       StringPicture(
-        SvgPicture.svgStringDecoderBuilder(null),
+        SvgPicture.svgStringDecoderBuilder,
         svgString,
       ),
       null,
@@ -135,7 +135,7 @@ void main() {
 
     await precachePicture(
       StringPicture(
-        SvgPicture.svgStringDecoderBuilder(null),
+        SvgPicture.svgStringDecoderBuilder,
         svgString,
       ),
       tester.element(find.text('test_text')),

--- a/test/picture_cache_test.dart
+++ b/test/picture_cache_test.dart
@@ -75,7 +75,7 @@ void main() {
     expect(PictureProvider.cache.count, 0);
     await precachePicture(
       StringPicture(
-        SvgPicture.svgStringDecoder,
+        SvgPicture.svgStringDecoderBuilder(null),
         svgString,
       ),
       tester.element(find.text('test_text')),
@@ -110,7 +110,7 @@ void main() {
     expect(PictureProvider.cache.count, 0);
     await precachePicture(
       StringPicture(
-        SvgPicture.svgStringDecoder,
+        SvgPicture.svgStringDecoderBuilder(null),
         svgString,
       ),
       null,
@@ -135,7 +135,7 @@ void main() {
 
     await precachePicture(
       StringPicture(
-        SvgPicture.svgStringDecoder,
+        SvgPicture.svgStringDecoderBuilder(null),
         svgString,
       ),
       tester.element(find.text('test_text')),

--- a/test/picture_provider_test.dart
+++ b/test/picture_provider_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockPictureInfo extends Mock implements PictureInfo {}
+
+class MockFile extends Mock implements File {}
+
+void main() {
+  group('PictureProvider', () {
+    Color? currentColor;
+
+    PictureInfoDecoder<T> decoderBuilder<T>(Color? color) {
+      currentColor = color;
+      return (T bytes, ColorFilter? colorFilter, String key) async =>
+          MockPictureInfo();
+    }
+
+    test(
+        'NetworkPicture rebuilds the decoder using decoderBuilder '
+        'when currentColor changes', () async {
+      const Color color = Color(0xFFB0E3BE);
+      final NetworkPicture networkPicture =
+          NetworkPicture(decoderBuilder, 'url');
+
+      final PictureInfoDecoder<Uint8List> decoder = networkPicture.decoder;
+
+      expect(decoder, isNotNull);
+
+      // Update the currentColor of PictureProvider.
+      networkPicture.currentColor = color;
+
+      expect(
+        decoder,
+        isNot(equals(networkPicture.decoder)),
+      );
+
+      expect(
+        currentColor,
+        equals(color),
+      );
+    });
+
+    test(
+        'FilePicture rebuilds the decoder using decoderBuilder '
+        'when currentColor changes', () async {
+      const Color color = Color(0xFFB0E3BE);
+      final FilePicture filePicture = FilePicture(decoderBuilder, MockFile());
+
+      final PictureInfoDecoder<Uint8List> decoder = filePicture.decoder;
+
+      expect(decoder, isNotNull);
+
+      // Update the currentColor of PictureProvider.
+      filePicture.currentColor = color;
+
+      expect(
+        decoder,
+        isNot(equals(filePicture.decoder)),
+      );
+
+      expect(
+        currentColor,
+        equals(color),
+      );
+    });
+
+    test(
+        'MemoryPicture rebuilds the decoder using decoderBuilder '
+        'when currentColor changes', () async {
+      const Color color = Color(0xFFB0E3BE);
+      final MemoryPicture memoryPicture =
+          MemoryPicture(decoderBuilder, Uint8List(0));
+
+      final PictureInfoDecoder<Uint8List> decoder = memoryPicture.decoder;
+
+      expect(decoder, isNotNull);
+
+      // Update the currentColor of PictureProvider.
+      memoryPicture.currentColor = color;
+
+      expect(
+        decoder,
+        isNot(equals(memoryPicture.decoder)),
+      );
+
+      expect(
+        currentColor,
+        equals(color),
+      );
+    });
+
+    test(
+        'StringPicture rebuilds the decoder using decoderBuilder '
+        'when currentColor changes', () async {
+      const Color color = Color(0xFFB0E3BE);
+      final StringPicture stringPicture = StringPicture(decoderBuilder, '');
+
+      final PictureInfoDecoder<String> decoder = stringPicture.decoder;
+
+      expect(decoder, isNotNull);
+
+      // Update the currentColor of PictureProvider.
+      stringPicture.currentColor = color;
+
+      expect(
+        decoder,
+        isNot(equals(stringPicture.decoder)),
+      );
+
+      expect(
+        currentColor,
+        equals(color),
+      );
+    });
+
+    test(
+        'ExactAssetPicture rebuilds the decoder using decoderBuilder '
+        'when currentColor changes', () async {
+      const Color color = Color(0xFFB0E3BE);
+      final ExactAssetPicture exactAssetPicture =
+          ExactAssetPicture(decoderBuilder, '');
+
+      final PictureInfoDecoder<String> decoder = exactAssetPicture.decoder;
+
+      expect(decoder, isNotNull);
+
+      // Update the currentColor of PictureProvider.
+      exactAssetPicture.currentColor = color;
+
+      expect(
+        decoder,
+        isNot(equals(exactAssetPicture.decoder)),
+      );
+
+      expect(
+        currentColor,
+        equals(color),
+      );
+    });
+  });
+}

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -1,7 +1,8 @@
-import 'dart:ui' show PathFillType;
+import 'dart:ui' show Color, PathFillType;
 
 import 'package:flutter_svg/parser.dart';
 import 'package:flutter_svg/src/svg/parsers.dart';
+import 'package:flutter_svg/src/svg/theme.dart';
 import 'package:flutter_svg/src/vector_drawable.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -272,5 +273,287 @@ void main() {
     expect(find<DrawableText>(root, 'preserve-space') != null, true);
     // Empty text elements get removed
     expect(find<DrawableText>(root, 'remove-space') != null, false);
+  });
+
+  group('currentColor', () {
+    group('stroke', () {
+      test(
+          'respects currentColor from SvgTheme '
+          'when no color attribute exists on the parent', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+   <circle id="circle" r="25" cx="70" cy="70" stroke="currentColor" fill="none" stroke-width="5" />
+</svg>''';
+
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: currentColor),
+        );
+
+        final DrawableShape? circle = find<DrawableShape>(root, 'circle');
+
+        expect(circle, isNotNull);
+
+        expect(
+          circle!.style.stroke?.color,
+          equals(currentColor),
+        );
+      });
+
+      test(
+          'respects currentColor from SvgTheme '
+          'when the parent uses currentColor', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg color="currentColor" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+  <g>
+    <circle id="circle" r="25" cx="70" cy="70" stroke="currentColor" fill="none" stroke-width="5" />
+  </g>
+</svg>''';
+
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: currentColor),
+        );
+
+        final DrawableShape? circle = find<DrawableShape>(root, 'circle');
+
+        expect(circle, isNotNull);
+
+        expect(
+          circle!.style.stroke?.color,
+          equals(currentColor),
+        );
+      });
+
+      test(
+          'respects currentColor from the parent '
+          'when the parent overrides currentColor', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg color="currentColor" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+  <g color="#c460b7">
+    <circle id="circle" r="25" cx="70" cy="70" stroke="currentColor" fill="none" stroke-width="5" />
+  </g>
+</svg>''';
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: Color(0xFFB0E3BE)),
+        );
+
+        final DrawableShape? circle = find<DrawableShape>(root, 'circle');
+
+        expect(circle, isNotNull);
+
+        expect(
+          circle!.style.stroke?.color,
+          equals(const Color(0xffC460B7)),
+        );
+      });
+    });
+
+    group('fill', () {
+      test(
+          'respects currentColor from SvgTheme '
+          'when no color attribute exists on the parent', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+   <circle id="circle" r="25" cx="70" cy="70" fill="currentColor" />
+</svg>''';
+
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: currentColor),
+        );
+
+        final DrawableShape? circle = find<DrawableShape>(root, 'circle');
+
+        expect(circle, isNotNull);
+
+        expect(
+          circle!.style.fill?.color,
+          equals(currentColor),
+        );
+      });
+
+      test(
+          'respects currentColor from SvgTheme '
+          'when the parent uses currentColor', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg color="currentColor" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+  <g>
+    <circle id="circle" r="25" cx="70" cy="70" fill="currentColor" />
+  </g>
+</svg>''';
+
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: currentColor),
+        );
+
+        final DrawableShape? circle = find<DrawableShape>(root, 'circle');
+
+        expect(circle, isNotNull);
+
+        expect(
+          circle!.style.fill?.color,
+          equals(currentColor),
+        );
+      });
+
+      test(
+          'respects currentColor from the parent '
+          'when the parent overrides currentColor', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg color="currentColor" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+  <g color="#c460b7">
+    <circle id="circle" r="25" cx="70" cy="70" fill="currentColor" />
+  </g>
+</svg>''';
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: Color(0xFFB0E3BE)),
+        );
+
+        final DrawableShape? circle = find<DrawableShape>(root, 'circle');
+
+        expect(circle, isNotNull);
+
+        expect(
+          circle!.style.fill?.color,
+          equals(const Color(0xFFC460B7)),
+        );
+      });
+    });
+
+    group('stop-color', () {
+      test(
+          'respects currentColor from SvgTheme '
+          'when no color attribute exists on the parent', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 166 202" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+    <defs>
+        <linearGradient id="gradient-1">
+            <stop id="stop-1" offset="20%" stop-color="currentColor" stop-opacity="0.5" />
+            <stop id="stop-2" offset="85%" stop-color="currentColor" stop-opacity="0.8" />
+        </linearGradient>
+    </defs>
+    <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#gradient-1)" />
+</svg>''';
+
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: currentColor),
+        );
+
+        final DrawableLinearGradient? gradient =
+            root.definitions.getGradient('url(#gradient-1)');
+
+        expect(gradient, isNotNull);
+
+        expect(
+          gradient!.colors?[0],
+          equals(currentColor.withOpacity(0.5)),
+        );
+
+        expect(
+          gradient.colors?[1],
+          equals(currentColor.withOpacity(0.8)),
+        );
+      });
+
+      test(
+          'respects currentColor from SvgTheme '
+          'when the parent uses currentColor', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg color="currentColor" viewBox="0 0 166 202" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+    <defs>
+        <linearGradient id="gradient-1">
+            <stop id="stop-1" offset="20%" stop-color="currentColor" stop-opacity="0.5" />
+            <stop id="stop-2" offset="85%" stop-color="currentColor" stop-opacity="0.8" />
+        </linearGradient>
+    </defs>
+    <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#gradient-1)" />
+</svg>''';
+
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: currentColor),
+        );
+
+        final DrawableLinearGradient? gradient =
+            root.definitions.getGradient('url(#gradient-1)');
+
+        expect(gradient, isNotNull);
+
+        expect(
+          gradient!.colors?[0],
+          equals(currentColor.withOpacity(0.5)),
+        );
+
+        expect(
+          gradient.colors?[1],
+          equals(currentColor.withOpacity(0.8)),
+        );
+      });
+
+      test(
+          'respects currentColor from the parent '
+          'when the parent overrides currentColor', () async {
+        const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
+<svg color="currentColor" viewBox="0 0 166 202" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
+    <g color="#c460b7">
+        <defs>
+            <linearGradient id="gradient-1">
+                <stop id="stop-1" offset="20%" stop-color="currentColor" stop-opacity="0.5" />
+                <stop id="stop-2" offset="85%" stop-color="currentColor" stop-opacity="0.8" />
+            </linearGradient>
+        </defs>
+        <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#gradient-1)" />
+    </g>
+</svg>''';
+
+        final SvgParser parser = SvgParser();
+        final DrawableRoot root = await parser.parse(
+          svgStr,
+          theme: const SvgTheme(currentColor: Color(0xFFB0E3BE)),
+        );
+
+        final DrawableLinearGradient? gradient =
+            root.definitions.getGradient('url(#gradient-1)');
+
+        expect(gradient, isNotNull);
+
+        expect(
+          gradient!.colors?[0],
+          equals(const Color(0xFFC460B7).withOpacity(0.5)),
+        );
+
+        expect(
+          gradient.colors?[1],
+          equals(const Color(0xFFC460B7).withOpacity(0.8)),
+        );
+      });
+    });
   });
 }

--- a/test/theme_test.dart
+++ b/test/theme_test.dart
@@ -1,0 +1,45 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/src/svg/theme.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SvgTheme', () {
+    group('constructor', () {
+      test('sets colorFilter', () {
+        const ColorFilter colorFilter =
+            ColorFilter.mode(Color(0xFF00FF00), BlendMode.color);
+
+        expect(
+          SvgTheme(colorFilter: colorFilter).colorFilter,
+          equals(colorFilter),
+        );
+      });
+
+      test('sets currentColor', () {
+        const Color currentColor = Color(0xFFB0E3BE);
+
+        expect(
+          SvgTheme(currentColor: currentColor).currentColor,
+          equals(currentColor),
+        );
+      });
+    });
+
+    test('supports value equality', () {
+      expect(
+        SvgTheme(
+          colorFilter: ColorFilter.mode(Color(0xFF00FF00), BlendMode.darken),
+          currentColor: Color(0xFF6F2173),
+        ),
+        equals(
+          SvgTheme(
+            colorFilter: ColorFilter.mode(Color(0xFF00FF00), BlendMode.darken),
+            currentColor: Color(0xFF6F2173),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/theme_test.dart
+++ b/test/theme_test.dart
@@ -7,16 +7,6 @@ import 'package:test/test.dart';
 void main() {
   group('SvgTheme', () {
     group('constructor', () {
-      test('sets colorFilter', () {
-        const ColorFilter colorFilter =
-            ColorFilter.mode(Color(0xFF00FF00), BlendMode.color);
-
-        expect(
-          SvgTheme(colorFilter: colorFilter).colorFilter,
-          equals(colorFilter),
-        );
-      });
-
       test('sets currentColor', () {
         const Color currentColor = Color(0xFFB0E3BE);
 
@@ -30,12 +20,10 @@ void main() {
     test('supports value equality', () {
       expect(
         SvgTheme(
-          colorFilter: ColorFilter.mode(Color(0xFF00FF00), BlendMode.darken),
           currentColor: Color(0xFF6F2173),
         ),
         equals(
           SvgTheme(
-            colorFilter: ColorFilter.mode(Color(0xFF00FF00), BlendMode.darken),
             currentColor: Color(0xFF6F2173),
           ),
         ),

--- a/test/vector_drawable_test.dart
+++ b/test/vector_drawable_test.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_svg/src/svg/theme.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -33,7 +34,9 @@ void main() {
 </svg>
 ''',
       false,
-      const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color),
+      const SvgTheme(
+        colorFilter: ColorFilter.mode(Color(0xFF00FF00), BlendMode.color),
+      ),
       'test',
     );
     final Image image = await info.picture.toImage(2, 2);

--- a/test/vector_drawable_test.dart
+++ b/test/vector_drawable_test.dart
@@ -34,9 +34,8 @@ void main() {
 </svg>
 ''',
       false,
-      const SvgTheme(
-        colorFilter: ColorFilter.mode(Color(0xFF00FF00), BlendMode.color),
-      ),
+      const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color),
+      const SvgTheme(),
       'test',
     );
     final Image image = await info.picture.toImage(2, 2);

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_svg/src/svg/theme.dart';
 import 'package:flutter_svg/src/unbounded_color_filtered.dart';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -566,6 +567,7 @@ void main() {
       (WidgetTester tester) async {
     await svg.fromSvgString(
         '<svg viewBox="0 0 166 202"><svg viewBox="0 0 166 202"></svg></svg>',
+        const SvgTheme(),
         'test');
     final UnsupportedError error = tester.takeException() as UnsupportedError;
     expect(error.message, 'Unsupported nested <svg> element.');

--- a/test/xml_svg_test.dart
+++ b/test/xml_svg_test.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_svg/src/svg/xml_parsers.dart';
 import 'package:flutter_svg/src/utilities/xml.dart';
 import 'package:test/test.dart';
@@ -196,5 +197,43 @@ void main() {
 
     expect(parseTextDecorationStyle(null), isNull);
     expect(() => parseTextDecorationStyle('invalid'), throwsUnsupportedError);
+  });
+
+  group('parseStyle', () {
+    test('uses currentColor for stroke color', () {
+      const Color currentColor = Color(0xFFB0E3BE);
+      final XmlStartElementEvent svg =
+          parseEvents('<svg stroke="currentColor" />').first
+              as XmlStartElementEvent;
+
+      final DrawableStyle svgStyle = parseStyle(
+        'test',
+        svg.attributes.toAttributeMap(),
+        DrawableDefinitionServer(),
+        null,
+        null,
+        currentColor: currentColor,
+      );
+
+      expect(svgStyle.stroke?.color, equals(currentColor));
+    });
+
+    test('uses currentColor for fill color', () {
+      const Color currentColor = Color(0xFFB0E3BE);
+      final XmlStartElementEvent svg =
+          parseEvents('<svg fill="currentColor" />').first
+              as XmlStartElementEvent;
+
+      final DrawableStyle svgStyle = parseStyle(
+        'test',
+        svg.attributes.toAttributeMap(),
+        DrawableDefinitionServer(),
+        null,
+        null,
+        currentColor: currentColor,
+      );
+
+      expect(svgStyle.fill?.color, equals(currentColor));
+    });
   });
 }

--- a/tool/gen_golden.dart
+++ b/tool/gen_golden.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
+import 'package:flutter_svg/src/svg/theme.dart';
 import 'package:flutter_svg/src/vector_drawable.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:path/path.dart' as path;
@@ -20,7 +21,7 @@ Future<Image> getSvgImage(String svgData) async {
   const Size size = Size(200.0, 200.0);
 
   final DrawableRoot svgRoot =
-      await svg.fromSvgString(svgData, 'GenGoldenTest');
+      await svg.fromSvgString(svgData, const SvgTheme(), 'GenGoldenTest');
   svgRoot.scaleCanvasToViewBox(canvas, size);
   svgRoot.clipCanvasToViewBox(canvas);
 


### PR DESCRIPTION
Adds support for [`currentColor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword) to `SvgPicture`.

- Introduced `SvgTheme` used when parsing an SVG picture (includes `currentColor`).
- Introduced `DefaultSvgTheme`, an inherited widget used to provide `SvgTheme` to `SvgPicture`.
- The `SvgPicture` provides the `currentColor` (from the widget's property if given, otherwise fallbacks to the `currentColor` inherited from `DefaultSvgTheme`) to the `SvgParserState`.
- `SvgParserState` now parses the [`color`](https://www.w3.org/TR/SVG11/color.html) attribute of SVG elements and provides the value to descendant elements. If a nested element defines its color as `currentColor`, then it uses the latest (deepest) `color` defined on its ancestor element. If no `color` is defined on ancestors, then it fallbacks to the value of `currentColor` inherited from `SvgPicture`.
- Refactored `AvdPicture` not to extend `SvgPicture`. 