### PR TITLE
Requires Flutter >=2.4.0 for LayerHandle usage

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.24.0-6.0.pre"
+  flutter: ">=2.4.0-0.0.pre"
 
 ## For developing features that require new functionality in engine:
 # dependency_overrides:


### PR DESCRIPTION
The Flutter version constraint is out of date. This PR is bumping it to at least 2.4.0.

The commit that landed `LayerHandle` in flutter/flutter  is https://github.com/flutter/flutter/commit/025397ae3f925b316991912977367d3263cc4432.