### PR TITLE
Render performance optimisation suggestion

### DIFF
--- a/lib/src/render_picture.dart
+++ b/lib/src/render_picture.dart
@@ -122,7 +122,10 @@ class RenderPicture extends RenderBox {
   PictureInfo? get picture => _picture;
   PictureInfo? _picture;
   set picture(PictureInfo? val) {
-    if (val == picture) {
+    bool b1 = val?.picture == _picture?.picture;
+    bool b2 = val?.size == _picture?.size;
+    bool b3 = val?.viewport == _picture?.viewport;
+    if (b1&&b2&&b3) {
       return;
     }
     _picture = val;


### PR DESCRIPTION
Hello,

The condition in set picture(PictureInfo? val) always returns false:
 if (val == picture) {
      return;
 }

This causes markNeedsPaint() to be set more often than it should, happens to me if I zoom the svg in an InteractiveViewer widget. 
Maybe you could implement a == operator in PictureInfo .

Regards,
Cristian