### PR TITLE
Make sure the SvgPicturestate holds on to a handle

### DIFF
--- a/lib/src/picture_stream.dart
+++ b/lib/src/picture_stream.dart
@@ -66,6 +66,16 @@ class PictureInfo {
 
   final Set<int> _handles = <int>{};
 
+  /// Returns the number of open picture handles on this picture info.
+  ///
+  /// Outside of debug mode, this returns null.
+  int? get debugHandleCount {
+    if (kDebugMode) {
+      return _handles.length;
+    }
+    return null;
+  }
+
   /// Creates a [PictureHandle] that keeps the [picture] from being disposed.
   ///
   /// Once all created handles are disposed, the underlying [picture] must not

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -792,7 +792,7 @@ class SvgParserState {
     this.theme,
     this._key,
     this._warningsAsErrors,
-  )
+  )   
   // ignore: unnecessary_null_comparison
   : assert(events != null),
         _eventIterator = events.iterator;

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -741,6 +741,7 @@ class SvgPicture extends StatefulWidget {
 
 class _SvgPictureState extends State<SvgPicture> {
   PictureInfo? _picture;
+  PictureHandle? _handle;
   PictureStream? _pictureStream;
   bool _isListeningToStream = false;
 
@@ -810,6 +811,8 @@ class _SvgPictureState extends State<SvgPicture> {
 
   void _handleImageChanged(PictureInfo? imageInfo, bool synchronousCall) {
     setState(() {
+      _handle?.dispose();
+      _handle = imageInfo?.createHandle();
       _picture = imageInfo;
     });
   }
@@ -822,8 +825,9 @@ class _SvgPictureState extends State<SvgPicture> {
       return;
     }
 
-    if (_isListeningToStream)
+    if (_isListeningToStream) {
       _pictureStream!.removeListener(_handleImageChanged);
+    }
 
     _pictureStream = newStream;
     if (_isListeningToStream) {
@@ -851,6 +855,8 @@ class _SvgPictureState extends State<SvgPicture> {
   void dispose() {
     assert(_pictureStream != null);
     _stopListeningToStream();
+    _handle?.dispose();
+    _handle = null;
     super.dispose();
   }
 

--- a/test/picture_stream_test.dart
+++ b/test/picture_stream_test.dart
@@ -5,7 +5,9 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('Picture does not get disposed if there are outstanding undisposed layers', () async {
+  test(
+      'Picture does not get disposed if there are outstanding undisposed layers',
+      () async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint()..color = const Color(0xFFFA0000));

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
-import 'dart:ui' show window;
+import 'dart:ui' show window, Picture;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -974,6 +974,152 @@ void main() {
       matchesGoldenFile('golden_widget/two_of_same.png'),
     );
   });
+
+  testWidgets(
+      'Update widget does not re-resolve the picture for identical keys',
+      (WidgetTester tester) async {
+    final int oldCacheSize = PictureProvider.cache.maximumSize;
+    PictureProvider.cache.maximumSize = 0;
+    final GlobalKey key = GlobalKey();
+    final FakePictureProvider provider = FakePictureProvider(
+      SvgPicture.svgStringDecoderBuilder,
+      simpleSvg,
+    );
+    expect(provider != provider, true);
+    expect(
+      provider.obtainKey(PictureConfiguration.empty),
+      provider.obtainKey(PictureConfiguration.empty),
+    );
+    expect(provider.resolveCount, 0);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SvgPicture(provider, key: key),
+      ),
+    );
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(provider.resolveCount, 1);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SvgPicture(provider, key: key),
+      ),
+    );
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(provider.resolveCount, 1);
+    PictureProvider.cache.maximumSize = oldCacheSize;
+  });
+
+  testWidgets(
+      'Update widget without a cache does not result in an disposed picture',
+      (WidgetTester tester) async {
+    final int oldCacheSize = PictureProvider.cache.maximumSize;
+    PictureProvider.cache.maximumSize = 0;
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SvgPicture(
+            FakePictureProvider(
+              SvgPicture.svgStringDecoderBuilder,
+              simpleSvg,
+            ),
+            key: key),
+      ),
+    );
+
+    expect(find.byKey(key), findsOneWidget);
+
+    // Update the widget with a new incompatible key.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SvgPicture(
+            FakePictureProvider(
+              SvgPicture.svgStringDecoderBuilder,
+              stickFigureSvgStr,
+            ),
+            key: key),
+      ),
+    );
+
+    expect(find.byKey(key), findsOneWidget);
+    await tester.pumpAndSettle();
+    PictureProvider.cache.maximumSize = oldCacheSize;
+  });
+
+  testWidgets('state maintains a handle', (WidgetTester tester) async {
+    final int oldCacheSize = PictureProvider.cache.maximumSize;
+    PictureProvider.cache.maximumSize = 1;
+    final GlobalKey key = GlobalKey();
+    final FakePictureProvider provider = FakePictureProvider(
+      SvgPicture.svgStringDecoderBuilder,
+      simpleSvg,
+    );
+
+    final PictureStream stream = provider.resolve(
+      createLocalPictureConfiguration(key.currentContext),
+    );
+    final Completer<PictureInfo> completer = Completer<PictureInfo>();
+    void listener(PictureInfo? info, bool syncCall) {
+      completer.complete(info!);
+    }
+
+    stream.addListener(listener);
+
+    final PictureInfo info = await completer.future;
+    expect(info.debugHandleCount, 1);
+    stream.removeListener(listener);
+    // Still in cache.
+    expect(info.debugHandleCount, 1);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SvgPicture(provider, key: key),
+      ),
+    );
+    expect(find.byKey(key), findsOneWidget);
+    expect(info.debugHandleCount, 3);
+    PictureProvider.cache.clear();
+    expect(info.debugHandleCount, 3);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(info.debugHandleCount, 0);
+
+    PictureProvider.cache.maximumSize = oldCacheSize;
+  });
+}
+
+class FakePictureProvider extends StringPicture {
+  FakePictureProvider(
+    PictureInfoDecoderBuilder<String> decoderBuilder,
+    String string,
+  ) : super(decoderBuilder, string);
+
+  int resolveCount = 0;
+
+  @override
+  PictureStream resolve(
+    PictureConfiguration picture, {
+    PictureErrorListener? onError,
+  }) {
+    resolveCount += 1;
+    return super.resolve(picture, onError: onError);
+  }
+
+  @override
+  // ignore: hash_and_equals, avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    // Picture providers should be compared based on key. Make sure tests don't
+    // cheat this check by using an identical provider.
+    return false;
+  }
 }
 
 class FakeAssetBundle extends Fake implements AssetBundle {

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
-import 'dart:ui' show window, Picture;
+import 'dart:ui' show window;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -973,45 +973,6 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('golden_widget/two_of_same.png'),
     );
-  });
-
-  testWidgets(
-      'Update widget does not re-resolve the picture for identical keys',
-      (WidgetTester tester) async {
-    final int oldCacheSize = PictureProvider.cache.maximumSize;
-    PictureProvider.cache.maximumSize = 0;
-    final GlobalKey key = GlobalKey();
-    final FakePictureProvider provider = FakePictureProvider(
-      SvgPicture.svgStringDecoderBuilder,
-      simpleSvg,
-    );
-    expect(provider != provider, true);
-    expect(
-      provider.obtainKey(PictureConfiguration.empty),
-      provider.obtainKey(PictureConfiguration.empty),
-    );
-    expect(provider.resolveCount, 0);
-
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: SvgPicture(provider, key: key),
-      ),
-    );
-
-    expect(find.byKey(key), findsOneWidget);
-    expect(provider.resolveCount, 1);
-
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: SvgPicture(provider, key: key),
-      ),
-    );
-
-    expect(find.byKey(key), findsOneWidget);
-    expect(provider.resolveCount, 1);
-    PictureProvider.cache.maximumSize = oldCacheSize;
   });
 
   testWidgets(


### PR DESCRIPTION
Fixes an issue where a didUpdateWidget can result in disposing the picture too early.