### PR TITLE
Extends SvgTheme to have locale and decideFontFamily.

### DIFF
--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -1786,9 +1786,16 @@ class SvgParserState {
     throw StateError('Could not parse "$colorString" as a color.');
   }
 
-  /// Process CSS style font family list to decide a font family.
+  /// Parse CSS style font family list to decide a font family.
   String? parseFontFamily(String? fontFamily) {
-    return theme.decideFontFamily?.call(_parseStringList(fontFamily));
+    final fontFamilies = _parseStringList(fontFamily);
+    if (theme.decideFontFamily != null) {
+      return theme.decideFontFamily!(fontFamilies);
+    }
+    if (fontFamilies == null || fontFamilies.isEmpty) {
+      return null;
+    }
+    return fontFamilies[0];
   }
 
   static List<String>? _parseStringList(String? list) {
@@ -1818,7 +1825,9 @@ class SvgParserState {
       }
     }
     _addIfNotEmptyString(out, sb.toString());
-    return out;
+    return out.isNotEmpty
+        ? out
+        : null; // if the list is empty, return null instead.
   }
 
   static void _addIfNotEmptyString(List<String> list, String s) {

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -1789,7 +1789,7 @@ class SvgParserState {
 
   /// Parse CSS style font family list to decide a font family.
   String? parseFontFamily(String? fontFamily) {
-    final fontFamilies = _parseStringList(fontFamily);
+    final List<String>? fontFamilies = _parseStringList(fontFamily);
     if (theme.resolveFontFamily != null) {
       return theme.resolveFontFamily!(fontFamilies);
     }

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -1789,8 +1789,8 @@ class SvgParserState {
   /// Parse CSS style font family list to decide a font family.
   String? parseFontFamily(String? fontFamily) {
     final fontFamilies = _parseStringList(fontFamily);
-    if (theme.decideFontFamily != null) {
-      return theme.decideFontFamily!(fontFamilies);
+    if (theme.resolveFontFamily != null) {
+      return theme.resolveFontFamily!(fontFamilies);
     }
     if (fontFamilies == null || fontFamilies.isEmpty) {
       return null;

--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -193,7 +193,8 @@ Paragraph createParagraph(
   DrawablePaint? foregroundOverride,
   Locale? locale,
 ) {
-  final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(locale: locale))
+  final ParagraphBuilder builder = ParagraphBuilder(
+      ParagraphStyle(locale: locale ?? PlatformDispatcher.instance.locale))
     ..pushStyle(
       style.textStyle!.toFlutterTextStyle(
         foregroundOverride: foregroundOverride,

--- a/lib/src/svg/parsers.dart
+++ b/lib/src/svg/parsers.dart
@@ -191,8 +191,9 @@ Paragraph createParagraph(
   String text,
   DrawableStyle style,
   DrawablePaint? foregroundOverride,
+  Locale? locale,
 ) {
-  final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle())
+  final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(locale: locale))
     ..pushStyle(
       style.textStyle!.toFlutterTextStyle(
         foregroundOverride: foregroundOverride,

--- a/lib/src/svg/theme.dart
+++ b/lib/src/svg/theme.dart
@@ -35,6 +35,9 @@ class SvgTheme {
   final Locale? locale;
 
   /// Decide a font family based on specified font families.
+  /// [fontFamilies] may be null but never be an empty list.
+  /// The function may return null if it could not determine suitable font and in that case,
+  /// the text is rendered using the default font.
   final String? Function(List<String>? fontFamilies)? decideFontFamily;
 
   @override

--- a/lib/src/svg/theme.dart
+++ b/lib/src/svg/theme.dart
@@ -13,6 +13,8 @@ class SvgTheme {
     this.currentColor,
     this.fontSize = 14,
     double? xHeight,
+    this.locale,
+    this.decideFontFamily,
   }) : xHeight = xHeight ?? fontSize / 2;
 
   /// The default color applied to SVG elements that inherit the color property.
@@ -28,6 +30,13 @@ class SvgTheme {
   /// See: https://www.w3.org/TR/SVG11/coords.html#Units, https://en.wikipedia.org/wiki/X-height
   final double xHeight;
 
+  /// Locale used when rendering texts.
+  /// See: https://github.com/dnfield/flutter_svg/issues/688
+  final Locale? locale;
+
+  /// Decide a font family based on specified font families.
+  final String? Function(List<String>? fontFamilies)? decideFontFamily;
+
   @override
   bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType) {
@@ -37,14 +46,16 @@ class SvgTheme {
     return other is SvgTheme &&
         currentColor == other.currentColor &&
         fontSize == other.fontSize &&
-        xHeight == other.xHeight;
+        xHeight == other.xHeight &&
+        locale == other.locale &&
+        decideFontFamily == other.decideFontFamily;
   }
 
   @override
-  int get hashCode => hashValues(currentColor, fontSize, xHeight);
+  int get hashCode => hashValues(currentColor, fontSize, xHeight, locale, decideFontFamily);
 
   @override
   String toString() {
-    return 'SvgTheme(currentColor: $currentColor, fontSize: $fontSize, xHeight: $xHeight)';
+    return 'SvgTheme(currentColor: $currentColor, fontSize: $fontSize, xHeight: $xHeight, locale: $locale)';
   }
 }

--- a/lib/src/svg/theme.dart
+++ b/lib/src/svg/theme.dart
@@ -14,7 +14,7 @@ class SvgTheme {
     this.fontSize = 14,
     double? xHeight,
     this.locale,
-    this.decideFontFamily,
+    this.resolveFontFamily,
   }) : xHeight = xHeight ?? fontSize / 2;
 
   /// The default color applied to SVG elements that inherit the color property.
@@ -38,7 +38,7 @@ class SvgTheme {
   /// [fontFamilies] may be null but never be an empty list.
   /// The function may return null if it could not determine suitable font and in that case,
   /// the text is rendered using the default font.
-  final String? Function(List<String>? fontFamilies)? decideFontFamily;
+  final String? Function(List<String>? fontFamilies)? resolveFontFamily;
 
   @override
   bool operator ==(dynamic other) {
@@ -51,11 +51,12 @@ class SvgTheme {
         fontSize == other.fontSize &&
         xHeight == other.xHeight &&
         locale == other.locale &&
-        decideFontFamily == other.decideFontFamily;
+        resolveFontFamily == other.resolveFontFamily;
   }
 
   @override
-  int get hashCode => hashValues(currentColor, fontSize, xHeight, locale, decideFontFamily);
+  int get hashCode =>
+      hashValues(currentColor, fontSize, xHeight, locale, resolveFontFamily);
 
   @override
   String toString() {

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -800,7 +800,8 @@ class _SvgPictureState extends State<SvgPicture> {
       fontSize: fontSize,
       xHeight: xHeight,
       locale: widget.theme?.locale ?? defaultSvgTheme?.locale,
-      decideFontFamily: widget.theme?.decideFontFamily ?? defaultSvgTheme?.decideFontFamily,
+      resolveFontFamily:
+          widget.theme?.resolveFontFamily ?? defaultSvgTheme?.resolveFontFamily,
     );
   }
 

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -799,6 +799,8 @@ class _SvgPictureState extends State<SvgPicture> {
       currentColor: currentColor,
       fontSize: fontSize,
       xHeight: xHeight,
+      locale: widget.theme?.locale ?? defaultSvgTheme?.locale,
+      decideFontFamily: widget.theme?.decideFontFamily ?? defaultSvgTheme?.decideFontFamily,
     );
   }
 


### PR DESCRIPTION
For #688, I extended `SvgTheme` to have `locale` and also `decideFontFamily` callback that decide actual font from list of font families listed on `text` element.

This is just a draft PR but I want to discuss how to deal with such cases.