### PR TITLE
Remove redundant canvas.restore()

### DIFF
--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -953,9 +953,6 @@ class DrawableRoot implements DrawableParent {
     if (transform != null) {
       canvas.restore();
     }
-    if (viewport.viewBoxOffset != Offset.zero) {
-      canvas.restore();
-    }
   }
 
   /// Creates a [Picture] from this [DrawableRoot].

--- a/test/vector_drawable_test.dart
+++ b/test/vector_drawable_test.dart
@@ -108,9 +108,11 @@ void main() {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
 
+    canvas.save();
+
     final DrawableRoot svgRoot = await svg.fromSvgString(
       svgWithTransform,
-      'RestoieCanvasWithTransform',
+      'RestoreCanvasWithTransform',
     );
 
     svgRoot.scaleCanvasToViewBox(canvas, const Size.square(200));
@@ -118,7 +120,7 @@ void main() {
 
     svgRoot.draw(canvas, svgRoot.viewport.viewBoxRect);
 
-    expect(canvas.getSaveCount(), equals(1));
+    expect(canvas.getSaveCount(), equals(2));
 
     recorder.endRecording();
   });

--- a/test/vector_drawable_test.dart
+++ b/test/vector_drawable_test.dart
@@ -88,4 +88,38 @@ void main() {
         (mergedRoot.children.first as DrawableShape).style.stroke!;
     expect(strokePaintA.strokeWidth, strokePaintB.strokeWidth);
   });
+
+  test('restore canvas accordingly', () async {
+    //https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform
+    const String svgWithTransform = '''
+<svg viewBox="-40 0 150 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g fill="grey"
+     transform="rotate(-10 50 100)
+                translate(-36 45.5)
+                skewX(40)
+                scale(1 0.5)">
+    <path id="heart" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
+  </g>
+
+  <use xlink:href="#heart" fill="none" stroke="red"/>
+</svg>
+''';
+
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+
+    final DrawableRoot svgRoot = await svg.fromSvgString(
+      svgWithTransform,
+      'RestoieCanvasWithTransform',
+    );
+
+    svgRoot.scaleCanvasToViewBox(canvas, const Size.square(200));
+    svgRoot.clipCanvasToViewBox(canvas);
+
+    svgRoot.draw(canvas, svgRoot.viewport.viewBoxRect);
+
+    expect(canvas.getSaveCount(), equals(1));
+
+    recorder.endRecording();
+  });
 }

--- a/test/vector_drawable_test.dart
+++ b/test/vector_drawable_test.dart
@@ -90,18 +90,9 @@ void main() {
   });
 
   test('restore canvas accordingly', () async {
-    //https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform
-    const String svgWithTransform = '''
-<svg viewBox="-40 0 150 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <g fill="grey"
-     transform="rotate(-10 50 100)
-                translate(-36 45.5)
-                skewX(40)
-                scale(1 0.5)">
-    <path id="heart" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
-  </g>
-
-  <use xlink:href="#heart" fill="none" stroke="red"/>
+    const String svgWithViewBox = '''
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="1 1 15 15">
+  <path/>
 </svg>
 ''';
 
@@ -111,8 +102,8 @@ void main() {
     canvas.save();
 
     final DrawableRoot svgRoot = await svg.fromSvgString(
-      svgWithTransform,
-      'RestoreCanvasWithTransform',
+      svgWithViewBox,
+      'RestoreCanvasWithSvgViewBox',
     );
 
     svgRoot.scaleCanvasToViewBox(canvas, const Size.square(200));


### PR DESCRIPTION
The canvas is getting restored in some scenarios one time too much, which will lead to an exception and invalid canvas.

The value of `viewBoxOffset` does not have any effect on saving the canvas initially. The `save()`  is controlled by `transform != null` and eventually restored in L954.