### PR TITLE
Update project to support flutter 3.0

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -18,15 +18,6 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Displays an Android View that continues showing the launch screen
-                 Drawable until Flutter paints its first frame, then this splash
-                 screen fades out. A splash screen is useful to avoid any visual
-                 gap between the end of Android's launch screen and the painting of
-                 Flutter's first frame. -->
-            <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/lib/src/picture_stream.dart
+++ b/lib/src/picture_stream.dart
@@ -394,8 +394,7 @@ class OneFramePictureStreamCompleter extends PictureStreamCompleter {
   ///
   /// Errors are reported using [FlutterError.reportError] with the `silent`
   /// argument on [FlutterErrorDetails] set to true, meaning that by default the
-  /// message is only dumped to the console in debug mode (see [new
-  /// FlutterErrorDetails]).
+  /// message is only dumped to the console in debug mode (see [FlutterErrorDetails]).
   OneFramePictureStreamCompleter(
     Future<PictureInfo?> picture, {
     InformationCollector? informationCollector,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,21 +6,21 @@ version: 1.1.0
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
+  meta: ^1.7.0
   path_drawing: ^1.0.0
-  vector_math: ^2.1.0
+  vector_math: ^2.1.2
 
-  xml: ^5.0.0
+  xml: ^6.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  path: ^1.8.0
-  test: ^1.16.0
+  path: ^1.8.1
+  test: ^1.21.1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.4.0-0.0.pre"
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: ">=3.0.0"
 
 ## For developing features that require new functionality in engine:
 # dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   test: ^1.21.1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0-0 <3.0.0'
   flutter: ">=3.0.0"
 
 ## For developing features that require new functionality in engine:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
 
 environment:
   sdk: '>=2.17.0-0 <3.0.0'
-  flutter: ">=3.0.0"
+  flutter: ">=2.11.0-0.1.pre <3.0.0"
 
 ## For developing features that require new functionality in engine:
 # dependency_overrides:


### PR DESCRIPTION
This PR addresses #708.

Most plugins are migrating to Flutter 3.0 and there has been version solving incompatibilities due to flutter_svg using xml ^5.0.0.

#### Changes:
- Updated plugins to latest resolvable
  - There were no breaking changes according to their changelogs published in pub.dev
- Dart requirement set to 2.17
- Removed deprecated splash screen. ([See here](https://docs.flutter.dev/development/ui/advanced/splash-screen#migrating-from-manifest--activity-defined-custom-splash-screens))
- Removed deprecated **new** keyword in comment reference. ([See here](https://dart.dev/tools/diagnostic-messages#deprecated_new_in_comment_reference))