### PR TITLE
Added the flutter_lints to the development dependency for project 'example'

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,9 @@ dependencies:
   flutter_svg:
     path: ../
 
+dev_dependencies:
+  flutter_lints: ^2.0.1
+
 # The following section is specific to Flutter.
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Added a missing dependency to the "example" project to resolve a warning from flutter analyze command:
```
flutter_svg> flutter analyze
Analyzing flutter_svg...

warning - The include file 'package:flutter_lints/flutter.yaml' in '\flutter_svg\example\analysis_options.yaml' can't be found when analyzing
       '\flutter_svg\example' - example\analysis_options.yaml:10:10 - include_file_not_found

1 issue found. (ran in 1.6s)

```