### PR TITLE
Defs and refs

### DIFF
--- a/example/assets/flutter_logo.svg
+++ b/example/assets/flutter_logo.svg
@@ -1,4 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    <path fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
+    <path fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
+    <path fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
+    <g transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+        <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+        <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+    </g>
+    <path d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
     <defs>
         <linearGradient id="triangleGradient">
             <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
@@ -9,12 +17,4 @@
             <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
         </linearGradient>
     </defs>
-    <path fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
-    <path fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
-    <path fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
-    <g transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
-        <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
-        <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
-    </g>
-    <path d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
 </svg>

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -733,8 +733,8 @@ class _Paths {
       getAttribute(attributes, 'height', def: '0'),
     )!;
     final Rect rect = Rect.fromLTWH(x, y, w, h);
-    String? rxRaw = getAttribute(attributes, 'rx');
-    String? ryRaw = getAttribute(attributes, 'ry');
+    String? rxRaw = getAttribute(attributes, 'rx', def: null);
+    String? ryRaw = getAttribute(attributes, 'ry', def: null);
     rxRaw ??= ryRaw;
     ryRaw ??= rxRaw;
 

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -1324,7 +1324,7 @@ class SvgParserState {
     XmlStartElementEvent? event,
     Map<String, String> attributes,
   ) async {
-    final String rawFill = getAttribute(attributes, 'fill', def: '')!; // TODO(ikbendewilliam): fill is null while it should be currentColor (works in stroke)
+    final String rawFill = getAttribute(attributes, 'fill', def: '')!;
     final String? rawFillOpacity = getAttribute(attributes, 'fill-opacity', def: '1.0');
     final String? rawOpacity = getAttribute(attributes, 'opacity', def: '');
     double opacity = parseDouble(rawFillOpacity)!.clamp(0.0, 1.0).toDouble();
@@ -1762,10 +1762,10 @@ class SvgParserState {
       _drawingCompleter?.complete();
     }
     await completer.future;
-    _unknownDefinitions.remove(ref);
     if (isInProcessing) {
       _processing.add(event);
     }
+    _unknownDefinitions.remove(ref);
   }
 }
 

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -848,8 +848,8 @@ class SvgParserState {
     if (_processing.isNotEmpty) {
       _drawingCompleter = Completer<void>();
       await _drawingCompleter!.future;
-      for (final String key in _unknownDefinitions.keys) {
-        reportMissingDef('', key, 'parse');
+      for (final String href in _unknownDefinitions.keys) {
+        reportMissingDef(_key, href, 'parse');
       }
     }
     if (_root == null) {

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -16,8 +16,10 @@ import 'parsers.dart';
 
 final Set<String> _unhandledElements = <String>{'title', 'desc'};
 
-typedef _ParseFunc = Future<void>? Function(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors);
-typedef _PathFunc = Path? Function(SvgParserState parserState, Map<String, String> attributes);
+typedef _ParseFunc = Future<void>? Function(SvgParserState parserState,
+    Map<String, String> attributes, bool warningsAsErrors);
+typedef _PathFunc = Path? Function(
+    SvgParserState parserState, Map<String, String> attributes);
 
 final RegExp _trimPattern = RegExp(r'[\r|\n|\t]');
 
@@ -45,7 +47,8 @@ const Map<String, _PathFunc> _svgPathFuncs = <String, _PathFunc>{
   'line': _Paths.line,
 };
 
-Offset _parseCurrentOffset(SvgParserState parserState, Map<String, String> attributes, Offset? lastOffset) {
+Offset _parseCurrentOffset(SvgParserState parserState,
+    Map<String, String> attributes, Offset? lastOffset) {
   final String? x = getAttribute(attributes, 'x', def: null);
   final String? y = getAttribute(attributes, 'y', def: null);
 
@@ -82,7 +85,8 @@ class _TextInfo {
 
 // ignore: avoid_classes_with_only_static_members
 class _Elements {
-  static Future<void>? svg(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors) async {
+  static Future<void>? svg(SvgParserState parserState,
+      Map<String, String> attributes, bool warningsAsErrors) async {
     final DrawableViewport? viewBox = parserState.parseViewBox(attributes);
 
     final String? id = getAttribute(attributes, 'id', def: '');
@@ -101,15 +105,19 @@ class _Elements {
       FlutterError.reportError(FlutterErrorDetails(
         exception: UnsupportedError(errorMessage),
         informationCollector: () => <DiagnosticsNode>[
-          ErrorDescription('The root <svg> element contained an unsupported nested SVG element.'),
+          ErrorDescription(
+              'The root <svg> element contained an unsupported nested SVG element.'),
           if (parserState._key != null) ErrorDescription(''),
-          if (parserState._key != null) DiagnosticsProperty<String>('Picture key', parserState._key),
+          if (parserState._key != null)
+            DiagnosticsProperty<String>('Picture key', parserState._key),
         ],
         library: 'SVG',
         context: ErrorDescription('in _Element.svg'),
       ));
       parserState._processing.add(parserState._currentStartElement);
-      final DrawableStyle style = await parserState.parseStyle(viewBox!.viewBoxRect, null, attributes, currentColor: color);
+      final DrawableStyle style = await parserState.parseStyle(
+          viewBox!.viewBoxRect, null, attributes,
+          currentColor: color);
       parserState._parentDrawables.addLast(
         _SvgGroupTuple(
           'svg',
@@ -127,26 +135,35 @@ class _Elements {
       viewBox!,
       <Drawable>[],
       parserState._definitions,
-      await parserState.parseStyle(viewBox.viewBoxRect, null, attributes, currentColor: color),
+      await parserState.parseStyle(viewBox.viewBoxRect, null, attributes,
+          currentColor: color),
       color: color,
       compatibilityTester: parserState._compatibilityTester,
     );
-    parserState.addGroup(parserState._currentStartElement!, parserState._root, id ?? '');
+    parserState.addGroup(
+        parserState._currentStartElement!, parserState._root, id ?? '');
     parserState._completeProcessing(id, parserState._currentStartElement);
     return;
   }
 
-  static Future<void> g(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors) async {
+  static Future<void> g(SvgParserState parserState,
+      Map<String, String> attributes, bool warningsAsErrors) async {
     if (parserState._currentStartElement?.isSelfClosing == true) {
       return;
     }
     final DrawableParent parent = parserState.currentGroup!;
-    final Color? color = parserState.parseColor(getAttribute(attributes, 'color', def: null), currentColor: parent.color ?? parserState.theme.currentColor) ?? parent.color;
+    final Color? color = parserState.parseColor(
+            getAttribute(attributes, 'color', def: null),
+            currentColor: parent.color ?? parserState.theme.currentColor) ??
+        parent.color;
     final String? id = getAttribute(attributes, 'id', def: '');
-    final XmlStartElementEvent currentElement = parserState._currentStartElement!;
+    final XmlStartElementEvent currentElement =
+        parserState._currentStartElement!;
     parserState._processing.add(currentElement);
 
-    final DrawableStyle style = await parserState.parseStyle(parserState.rootBounds, parent.style, attributes, currentColor: color);
+    final DrawableStyle style = await parserState.parseStyle(
+        parserState.rootBounds, parent.style, attributes,
+        currentColor: color);
     final DrawableGroup group = DrawableGroup(
       id,
       <Drawable>[],
@@ -159,11 +176,16 @@ class _Elements {
     parserState._completeProcessing(id, currentElement);
   }
 
-  static Future<void>? symbol(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors) async {
+  static Future<void>? symbol(SvgParserState parserState,
+      Map<String, String> attributes, bool warningsAsErrors) async {
     final DrawableParent parent = parserState.currentGroup!;
-    final Color? color = parserState.parseColor(getAttribute(attributes, 'color', def: null), currentColor: parent.color ?? parserState.theme.currentColor) ?? parent.color;
+    final Color? color = parserState.parseColor(
+            getAttribute(attributes, 'color', def: null),
+            currentColor: parent.color ?? parserState.theme.currentColor) ??
+        parent.color;
     final String? id = getAttribute(attributes, 'id', def: '');
-    final XmlStartElementEvent currentElement = parserState._currentStartElement!;
+    final XmlStartElementEvent currentElement =
+        parserState._currentStartElement!;
     parserState._processing.add(currentElement);
     final DrawableGroup group = DrawableGroup(
       id,
@@ -180,14 +202,17 @@ class _Elements {
     parserState.addGroup(currentElement, group, id ?? '');
   }
 
-  static Future<void>? use(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors) async {
+  static Future<void>? use(SvgParserState parserState,
+      Map<String, String> attributes, bool warningsAsErrors) async {
     final DrawableParent? parent = parserState.currentGroup;
     final String xlinkHref = getHrefAttribute(attributes)!;
     if (xlinkHref.isEmpty) {
       return;
     }
 
-    final Matrix4 transform = parseTransform(getAttribute(attributes, 'transform')) ?? Matrix4.identity();
+    final Matrix4 transform =
+        parseTransform(getAttribute(attributes, 'transform')) ??
+            Matrix4.identity();
     transform.translate(
       parserState.parseDoubleWithUnits(
         getAttribute(attributes, 'x', def: '0'),
@@ -198,7 +223,8 @@ class _Elements {
     );
 
     final String id = getAttribute(attributes, 'id') ?? '';
-    final XmlStartElementEvent currentElement = parserState._currentStartElement!;
+    final XmlStartElementEvent currentElement =
+        parserState._currentStartElement!;
     parserState._processing.add(currentElement);
     parserState
         .parseStyle(
@@ -208,7 +234,8 @@ class _Elements {
       currentColor: parent.color,
     )
         .then((DrawableStyle style) async {
-      final DrawableStyleable ref = await parserState._getDrawable(xlinkHref, currentElement);
+      final DrawableStyleable ref =
+          await parserState._getDrawable(xlinkHref, currentElement);
       final DrawableGroup group = DrawableGroup(
         id,
         <Drawable>[ref.mergeStyle(style)],
@@ -233,14 +260,18 @@ class _Elements {
         continue;
       }
       if (event is XmlStartElementEvent) {
-        final Map<String, String> attributes = event.attributes.toAttributeMap();
+        final Map<String, String> attributes =
+            event.attributes.toAttributeMap();
         final String rawOpacity = getAttribute(
           attributes,
           'stop-opacity',
           def: '1',
         )!;
-        final Color stopColor =
-            parserState.parseColor(getAttribute(attributes, 'stop-color'), currentColor: parent.color ?? parserState.theme.currentColor) ?? parent.color ?? colorBlack;
+        final Color stopColor = parserState.parseColor(
+                getAttribute(attributes, 'stop-color'),
+                currentColor: parent.color ?? parserState.theme.currentColor) ??
+            parent.color ??
+            colorBlack;
         colors.add(stopColor.withOpacity(parseDouble(rawOpacity)!));
 
         final String rawOffset = getAttribute(
@@ -281,13 +312,16 @@ class _Elements {
     final List<double> offsets = <double>[];
     final List<Color> colors = <Color>[];
 
-    final XmlStartElementEvent currentElement = parserState._currentStartElement!;
+    final XmlStartElementEvent currentElement =
+        parserState._currentStartElement!;
     if (parserState._currentStartElement!.isSelfClosing) {
       parserState._processing.add(currentElement);
       final String? href = getHrefAttribute(attributes);
-      final DrawableGradient ref = await parserState._getGradient(href ?? '', currentElement);
+      final DrawableGradient ref =
+          await parserState._getGradient(href ?? '', currentElement);
       if (gradientUnits == null) {
-        isObjectBoundingBox = ref.unitMode == GradientUnitMode.objectBoundingBox;
+        isObjectBoundingBox =
+            ref.unitMode == GradientUnitMode.objectBoundingBox;
       }
       colors.addAll(ref.colors!);
       offsets.addAll(ref.offsets!);
@@ -303,11 +337,27 @@ class _Elements {
       fx = parseDecimalOrPercentage(rawFx!);
       fy = parseDecimalOrPercentage(rawFy!);
     } else {
-      cx = isPercentage(rawCx!) ? parsePercentage(rawCx) * parserState.rootBounds.width + parserState.rootBounds.left : parserState.parseDoubleWithUnits(rawCx)!;
-      cy = isPercentage(rawCy!) ? parsePercentage(rawCy) * parserState.rootBounds.height + parserState.rootBounds.top : parserState.parseDoubleWithUnits(rawCy)!;
-      r = isPercentage(rawR!) ? parsePercentage(rawR) * ((parserState.rootBounds.height + parserState.rootBounds.width) / 2) : parserState.parseDoubleWithUnits(rawR)!;
-      fx = isPercentage(rawFx!) ? parsePercentage(rawFx) * parserState.rootBounds.width + parserState.rootBounds.left : parserState.parseDoubleWithUnits(rawFx)!;
-      fy = isPercentage(rawFy!) ? parsePercentage(rawFy) * parserState.rootBounds.height + parserState.rootBounds.top : parserState.parseDoubleWithUnits(rawFy)!;
+      cx = isPercentage(rawCx!)
+          ? parsePercentage(rawCx) * parserState.rootBounds.width +
+              parserState.rootBounds.left
+          : parserState.parseDoubleWithUnits(rawCx)!;
+      cy = isPercentage(rawCy!)
+          ? parsePercentage(rawCy) * parserState.rootBounds.height +
+              parserState.rootBounds.top
+          : parserState.parseDoubleWithUnits(rawCy)!;
+      r = isPercentage(rawR!)
+          ? parsePercentage(rawR) *
+              ((parserState.rootBounds.height + parserState.rootBounds.width) /
+                  2)
+          : parserState.parseDoubleWithUnits(rawR)!;
+      fx = isPercentage(rawFx!)
+          ? parsePercentage(rawFx) * parserState.rootBounds.width +
+              parserState.rootBounds.left
+          : parserState.parseDoubleWithUnits(rawFx)!;
+      fy = isPercentage(rawFy!)
+          ? parsePercentage(rawFy) * parserState.rootBounds.height +
+              parserState.rootBounds.top
+          : parserState.parseDoubleWithUnits(rawFy)!;
     }
 
     parserState._definitions.addGradient(
@@ -319,7 +369,9 @@ class _Elements {
         focalRadius: 0.0,
         colors: colors,
         offsets: offsets,
-        unitMode: isObjectBoundingBox ? GradientUnitMode.objectBoundingBox : GradientUnitMode.userSpaceOnUse,
+        unitMode: isObjectBoundingBox
+            ? GradientUnitMode.objectBoundingBox
+            : GradientUnitMode.userSpaceOnUse,
         spreadMethod: spreadMethod,
         transform: originalTransform?.storage,
       ),
@@ -349,13 +401,16 @@ class _Elements {
 
     final List<Color> colors = <Color>[];
     final List<double> offsets = <double>[];
-    final XmlStartElementEvent currentElement = parserState._currentStartElement!;
+    final XmlStartElementEvent currentElement =
+        parserState._currentStartElement!;
     if (parserState._currentStartElement!.isSelfClosing) {
       parserState._processing.add(currentElement);
       final String? href = getHrefAttribute(attributes);
-      final DrawableGradient ref = await parserState._getGradient(href ?? '', parserState._currentStartElement!);
+      final DrawableGradient ref = await parserState._getGradient(
+          href ?? '', parserState._currentStartElement!);
       if (gradientUnits == null) {
-        isObjectBoundingBox = ref.unitMode == GradientUnitMode.objectBoundingBox;
+        isObjectBoundingBox =
+            ref.unitMode == GradientUnitMode.objectBoundingBox;
       }
       colors.addAll(ref.colors!);
       offsets.addAll(ref.offsets!);
@@ -375,13 +430,25 @@ class _Elements {
       );
     } else {
       fromOffset = Offset(
-        isPercentage(x1) ? parsePercentage(x1) * parserState.rootBounds.width + parserState.rootBounds.left : parserState.parseDoubleWithUnits(x1)!,
-        isPercentage(y1) ? parsePercentage(y1) * parserState.rootBounds.height + parserState.rootBounds.top : parserState.parseDoubleWithUnits(y1)!,
+        isPercentage(x1)
+            ? parsePercentage(x1) * parserState.rootBounds.width +
+                parserState.rootBounds.left
+            : parserState.parseDoubleWithUnits(x1)!,
+        isPercentage(y1)
+            ? parsePercentage(y1) * parserState.rootBounds.height +
+                parserState.rootBounds.top
+            : parserState.parseDoubleWithUnits(y1)!,
       );
 
       toOffset = Offset(
-        isPercentage(x2) ? parsePercentage(x2) * parserState.rootBounds.width + parserState.rootBounds.left : parserState.parseDoubleWithUnits(x2)!,
-        isPercentage(y2) ? parsePercentage(y2) * parserState.rootBounds.height + parserState.rootBounds.top : parserState.parseDoubleWithUnits(y2)!,
+        isPercentage(x2)
+            ? parsePercentage(x2) * parserState.rootBounds.width +
+                parserState.rootBounds.left
+            : parserState.parseDoubleWithUnits(x2)!,
+        isPercentage(y2)
+            ? parsePercentage(y2) * parserState.rootBounds.height +
+                parserState.rootBounds.top
+            : parserState.parseDoubleWithUnits(y2)!,
       );
     }
     parserState._definitions.addGradient(
@@ -392,7 +459,9 @@ class _Elements {
         colors: colors,
         offsets: offsets,
         spreadMethod: spreadMethod,
-        unitMode: isObjectBoundingBox ? GradientUnitMode.objectBoundingBox : GradientUnitMode.userSpaceOnUse,
+        unitMode: isObjectBoundingBox
+            ? GradientUnitMode.objectBoundingBox
+            : GradientUnitMode.userSpaceOnUse,
         transform: originalTransform?.storage,
       ),
     );
@@ -400,8 +469,10 @@ class _Elements {
     parserState._completeProcessing(id, currentElement);
   }
 
-  static Future<void> clipPath(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors) async {
-    final String id = parserState.buildUrlIri(getAttribute(attributes, 'id') ?? '');
+  static Future<void> clipPath(SvgParserState parserState,
+      Map<String, String> attributes, bool warningsAsErrors) async {
+    final String id =
+        parserState.buildUrlIri(getAttribute(attributes, 'id') ?? '');
 
     final List<Path> paths = <Path>[];
     Path? currentPath;
@@ -413,9 +484,12 @@ class _Elements {
         final _PathFunc? pathFn = _svgPathFuncs[event.name];
 
         if (pathFn != null) {
-          final Path nextPath = parserState.applyTransformIfNeeded(pathFn(parserState, attributes), attributes)!;
-          nextPath.fillType = parserState.parseFillRule(attributes, 'clip-rule')!;
-          if (currentPath != null && nextPath.fillType != currentPath.fillType) {
+          final Path nextPath = parserState.applyTransformIfNeeded(
+              pathFn(parserState, attributes), attributes)!;
+          nextPath.fillType =
+              parserState.parseFillRule(attributes, 'clip-rule')!;
+          if (currentPath != null &&
+              nextPath.fillType != currentPath.fillType) {
             currentPath = nextPath;
             paths.add(currentPath);
           } else if (currentPath == null) {
@@ -426,7 +500,8 @@ class _Elements {
           }
         } else if (event.name == 'use') {
           final String xlinkHref = getHrefAttribute(attributes) ?? '';
-          final DrawableStyleable? definitionDrawable = await parserState._getDrawable(xlinkHref, event);
+          final DrawableStyleable? definitionDrawable =
+              await parserState._getDrawable(xlinkHref, event);
 
           void extractPathsFromDrawable(Drawable? target) {
             if (target is DrawableShape) {
@@ -438,16 +513,19 @@ class _Elements {
 
           extractPathsFromDrawable(definitionDrawable);
         } else {
-          final String errorMessage = 'Unsupported clipPath child ${event.name}';
+          final String errorMessage =
+              'Unsupported clipPath child ${event.name}';
           if (warningsAsErrors) {
             throw UnsupportedError(errorMessage);
           }
           FlutterError.reportError(FlutterErrorDetails(
             exception: UnsupportedError(errorMessage),
             informationCollector: () => <DiagnosticsNode>[
-              ErrorDescription('The <clipPath> element contained an unsupported child ${event.name}'),
+              ErrorDescription(
+                  'The <clipPath> element contained an unsupported child ${event.name}'),
               if (parserState._key != null) ErrorDescription(''),
-              if (parserState._key != null) DiagnosticsProperty<String>('Picture key', parserState._key),
+              if (parserState._key != null)
+                DiagnosticsProperty<String>('Picture key', parserState._key),
             ],
             library: 'SVG',
             context: ErrorDescription('in _Element.clipPath'),
@@ -459,7 +537,8 @@ class _Elements {
     parserState._markUnkownDefinitionComplete(parserState._buildHref(id));
   }
 
-  static Future<void> image(SvgParserState parserState, Map<String, String> attributes, bool warningsAsErrors) async {
+  static Future<void> image(SvgParserState parserState,
+      Map<String, String> attributes, bool warningsAsErrors) async {
     final String? href = getHrefAttribute(attributes);
     if (href == null) {
       return;
@@ -474,18 +553,27 @@ class _Elements {
     );
     final Image image = await resolveImage(href);
     final Size size = Size(
-      parserState.parseDoubleWithUnits(getAttribute(attributes, 'width', def: null)) ?? image.width.toDouble(),
-      parserState.parseDoubleWithUnits(getAttribute(attributes, 'height', def: null)) ?? image.height.toDouble(),
+      parserState.parseDoubleWithUnits(
+              getAttribute(attributes, 'width', def: null)) ??
+          image.width.toDouble(),
+      parserState.parseDoubleWithUnits(
+              getAttribute(attributes, 'height', def: null)) ??
+          image.height.toDouble(),
     );
     final DrawableParent parent = parserState._parentDrawables.last.drawable!;
     final DrawableStyle? parentStyle = parent.style;
     final DrawableParent group = parserState.currentGroup!;
     final String? id = getAttribute(attributes, 'id');
-    final Float64List? transform = parseTransform(getAttribute(attributes, 'transform'))?.storage;
-    final XmlStartElementEvent? currentElement = parserState._currentStartElement;
+    final Float64List? transform =
+        parseTransform(getAttribute(attributes, 'transform'))?.storage;
+    final XmlStartElementEvent? currentElement =
+        parserState._currentStartElement;
     parserState._processing.add(currentElement);
 
-    parserState.parseStyle(parserState.rootBounds, parentStyle, attributes, currentColor: parent.color).then((DrawableStyle style) {
+    parserState
+        .parseStyle(parserState.rootBounds, parentStyle, attributes,
+            currentColor: parent.color)
+        .then((DrawableStyle style) {
       final DrawableRasterImage drawable = DrawableRasterImage(
         id,
         image,
@@ -531,7 +619,9 @@ class _Elements {
       final Paragraph stroke = createParagraph(
         value,
         lastTextInfo.style,
-        DrawablePaint.isEmpty(lastTextInfo.style.stroke) ? transparentStroke : lastTextInfo.style.stroke,
+        DrawablePaint.isEmpty(lastTextInfo.style.stroke)
+            ? transparentStroke
+            : lastTextInfo.style.stroke,
       );
       parserState.currentGroup!.children!.add(
         DrawableText(
@@ -539,14 +629,16 @@ class _Elements {
           fill,
           stroke,
           lastTextInfo.offset,
-          lastTextInfo.style.textStyle!.anchor ?? DrawableTextAnchorPosition.start,
+          lastTextInfo.style.textStyle!.anchor ??
+              DrawableTextAnchorPosition.start,
           transform: lastTextInfo.transform?.storage,
         ),
       );
       lastTextWidth = fill.maxIntrinsicWidth;
     }
 
-    Future<void> _processStartElement(XmlStartElementEvent event, Map<String, String> attributes) async {
+    Future<void> _processStartElement(
+        XmlStartElementEvent event, Map<String, String> attributes) async {
       _TextInfo? lastTextInfo;
       if (textInfos.isNotEmpty) {
         lastTextInfo = textInfos.last;
@@ -556,7 +648,8 @@ class _Elements {
         attributes,
         lastTextInfo?.offset.translate(lastTextWidth, 0),
       );
-      Matrix4? transform = parseTransform(getAttribute(attributes, 'transform'));
+      Matrix4? transform =
+          parseTransform(getAttribute(attributes, 'transform'));
       if (lastTextInfo?.transform != null) {
         if (transform == null) {
           transform = lastTextInfo!.transform;
@@ -565,7 +658,8 @@ class _Elements {
         }
       }
 
-      final DrawableStyle? parentStyle = lastTextInfo?.style ?? parserState.currentGroup!.style;
+      final DrawableStyle? parentStyle =
+          lastTextInfo?.style ?? parserState.currentGroup!.style;
 
       textInfos.add(_TextInfo(
         await parserState.parseStyle(
@@ -605,7 +699,8 @@ class _Elements {
 
 // ignore: avoid_classes_with_only_static_members
 class _Paths {
-  static Path circle(SvgParserState parserState, Map<String, String> attributes) {
+  static Path circle(
+      SvgParserState parserState, Map<String, String> attributes) {
     final double cx = parserState.parseDoubleWithUnits(
       getAttribute(attributes, 'cx', def: '0'),
     )!;
@@ -653,15 +748,18 @@ class _Paths {
     return Path()..addRect(rect);
   }
 
-  static Path? polygon(SvgParserState parserState, Map<String, String> attributes) {
+  static Path? polygon(
+      SvgParserState parserState, Map<String, String> attributes) {
     return parsePathFromPoints(parserState, attributes, true);
   }
 
-  static Path? polyline(SvgParserState parserState, Map<String, String> attributes) {
+  static Path? polyline(
+      SvgParserState parserState, Map<String, String> attributes) {
     return parsePathFromPoints(parserState, attributes, false);
   }
 
-  static Path? parsePathFromPoints(SvgParserState parserState, Map<String, String> attributes, bool close) {
+  static Path? parsePathFromPoints(
+      SvgParserState parserState, Map<String, String> attributes, bool close) {
     final String points = getAttribute(attributes, 'points', def: '')!;
     if (points == '') {
       return null;
@@ -671,7 +769,8 @@ class _Paths {
     return parseSvgPathData(path);
   }
 
-  static Path ellipse(SvgParserState parserState, Map<String, String> attributes) {
+  static Path ellipse(
+      SvgParserState parserState, Map<String, String> attributes) {
     final double cx = parserState.parseDoubleWithUnits(
       getAttribute(attributes, 'cx', def: '0'),
     )!;
@@ -755,8 +854,10 @@ class SvgParserState {
   final String? _key;
   final bool _warningsAsErrors;
   final DrawableDefinitionServer _definitions = DrawableDefinitionServer();
-  final Map<String, Completer<void>> _unknownDefinitions = <String, Completer<void>>{};
-  final Map<String, List<XmlStartElementEvent?>> _waitingForDefinitions = <String, List<XmlStartElementEvent?>>{};
+  final Map<String, Completer<void>> _unknownDefinitions =
+      <String, Completer<void>>{};
+  final Map<String, List<XmlStartElementEvent?>> _waitingForDefinitions =
+      <String, List<XmlStartElementEvent?>>{};
   final Set<XmlStartElementEvent?> _processing = <XmlStartElementEvent?>{};
   final Queue<_SvgGroupTuple> _parentDrawables = ListQueue<_SvgGroupTuple>(10);
   Completer<void>? _drawingCompleter;
@@ -789,8 +890,10 @@ class SvgParserState {
       final XmlEvent event = _eventIterator.current;
       bool isSelfClosing = false;
       if (event is XmlStartElementEvent) {
-        final Map<String, String> attributeMap = event.attributes.toAttributeMap();
-        if (getAttribute(attributeMap, 'display') == 'none' || getAttribute(attributeMap, 'visibility') == 'hidden') {
+        final Map<String, String> attributeMap =
+            event.attributes.toAttributeMap();
+        if (getAttribute(attributeMap, 'display') == 'none' ||
+            getAttribute(attributeMap, 'visibility') == 'hidden') {
           print('SVG Warning: Discarding:\n\n  $event\n\n'
               'and any children it has since it is not visible.\n'
               'If that element is meant to be visible, the `display` or '
@@ -825,7 +928,8 @@ class SvgParserState {
     _compatibilityTester = _SvgCompatibilityTester();
     for (XmlEvent event in _readSubtree()) {
       if (event is XmlStartElementEvent) {
-        final Map<String, String> attributes = event.attributes.toAttributeMap();
+        final Map<String, String> attributes =
+            event.attributes.toAttributeMap();
         if (startElement(event, attributes)) {
           continue;
         }
@@ -881,7 +985,8 @@ class SvgParserState {
   }
 
   /// Appends a group to the collection.
-  void addGroup(XmlStartElementEvent event, DrawableParent? drawable, String id) {
+  void addGroup(
+      XmlStartElementEvent event, DrawableParent? drawable, String id) {
     _parentDrawables.addLast(_SvgGroupTuple(event.name, drawable));
     checkForIri(drawable, id);
   }
@@ -896,7 +1001,8 @@ class SvgParserState {
     final DrawableParent parent = _parentDrawables.last.drawable!;
     final DrawableStyle? parentStyle = parent.style;
     final Path path = pathFunc(this, attributes)!;
-    final Float64List? transform = parseTransform(getAttribute(attributes, 'transform'))?.storage;
+    final Float64List? transform =
+        parseTransform(getAttribute(attributes, 'transform'))?.storage;
     final String id = getAttribute(attributes, 'id', def: '') ?? '';
     final XmlStartElementEvent? currentElement = _currentStartElement;
     _processing.add(currentElement);
@@ -921,7 +1027,8 @@ class SvgParserState {
   }
 
   /// Potentially handles a starting element.
-  bool startElement(XmlStartElementEvent event, Map<String, String> attributes) {
+  bool startElement(
+      XmlStartElementEvent event, Map<String, String> attributes) {
     if (event.name == 'defs') {
       if (!event.isSelfClosing) {
         addGroup(
@@ -953,18 +1060,22 @@ class SvgParserState {
   /// Will only print an error once for unhandled/unexpected elements, except for
   /// `<style/>`, `<title/>`, and `<desc/>` elements.
   void unhandledElement(XmlStartElementEvent event) {
-    final String errorMessage = 'unhandled element ${event.name}; Picture key: $_key';
+    final String errorMessage =
+        'unhandled element ${event.name}; Picture key: $_key';
     if (_warningsAsErrors) {
       // Throw error instead of log warning.
       throw UnimplementedError(errorMessage);
     }
     if (event.name == 'style') {
       FlutterError.reportError(FlutterErrorDetails(
-        exception: UnimplementedError('The <style> element is not implemented in this library.'),
+        exception: UnimplementedError(
+            'The <style> element is not implemented in this library.'),
         informationCollector: () => <DiagnosticsNode>[
-          ErrorDescription('Style elements are not supported by this library and the requested SVG may not '
+          ErrorDescription(
+              'Style elements are not supported by this library and the requested SVG may not '
               'render as intended.'),
-          ErrorHint('If possible, ensure the SVG uses inline styles and/or attributes (which are '
+          ErrorHint(
+              'If possible, ensure the SVG uses inline styles and/or attributes (which are '
               'supported), or use a preprocessing utility such as svgcleaner to inline the '
               'styles for you.'),
           ErrorDescription(''),
@@ -985,7 +1096,8 @@ class SvgParserState {
   static const int kCssPointsPerInch = 72;
 
   /// The multiplicand to convert from CSS points to pixels.
-  static const double kPointsToPixelFactor = kCssPixelsPerInch / kCssPointsPerInch;
+  static const double kPointsToPixelFactor =
+      kCssPixelsPerInch / kCssPointsPerInch;
 
   /// Parses a `rawDouble` `String` to a `double`
   /// taking into account absolute and relative units
@@ -1092,8 +1204,12 @@ class SvgParserState {
     }
     assert(() {
       final RegExp notDigits = RegExp(r'[^\d\.]');
-      if (!raw.endsWith('px') && !raw.endsWith('em') && !raw.endsWith('ex') && raw.contains(notDigits)) {
-        print('Warning: Flutter SVG only supports the following formats for `width` and `height` on the SVG root:\n'
+      if (!raw.endsWith('px') &&
+          !raw.endsWith('em') &&
+          !raw.endsWith('ex') &&
+          raw.contains(notDigits)) {
+        print(
+            'Warning: Flutter SVG only supports the following formats for `width` and `height` on the SVG root:\n'
             '  width="100%"\n'
             '  width="100em"\n'
             '  width="100ex"\n'
@@ -1113,7 +1229,8 @@ class SvgParserState {
   ///
   /// The [respectWidthHeight] parameter specifies whether `width` and `height` attributes
   /// on the root SVG element should be treated in accordance with the specification.
-  DrawableViewport? parseViewBox(Map<String, String> attributes, {bool nullOk = false}) {
+  DrawableViewport? parseViewBox(Map<String, String> attributes,
+      {bool nullOk = false}) {
     final String viewBox = getAttribute(attributes, 'viewBox')!;
     final String rawWidth = getAttribute(attributes, 'width')!;
     final String rawHeight = getAttribute(attributes, 'height')!;
@@ -1210,7 +1327,8 @@ class SvgParserState {
 
   /// Parses a `spreadMethod` attribute into a [TileMode].
   TileMode parseTileMode(Map<String, String> attributes) {
-    final String? spreadMethod = getAttribute(attributes, 'spreadMethod', def: 'pad');
+    final String? spreadMethod =
+        getAttribute(attributes, 'spreadMethod', def: 'pad');
     switch (spreadMethod) {
       case 'pad':
         return TileMode.clamp;
@@ -1267,12 +1385,20 @@ class SvgParserState {
       opacity *= parseDouble(rawOpacity)!.clamp(0.0, 1.0);
     }
 
-    final String? rawStrokeCap = getAttribute(attributes, 'stroke-linecap', def: null);
-    final String? rawLineJoin = getAttribute(attributes, 'stroke-linejoin', def: null);
-    final String? rawMiterLimit = getAttribute(attributes, 'stroke-miterlimit', def: null);
-    final String? rawStrokeWidth = getAttribute(attributes, 'stroke-width', def: null);
+    final String? rawStrokeCap =
+        getAttribute(attributes, 'stroke-linecap', def: null);
+    final String? rawLineJoin =
+        getAttribute(attributes, 'stroke-linejoin', def: null);
+    final String? rawMiterLimit =
+        getAttribute(attributes, 'stroke-miterlimit', def: null);
+    final String? rawStrokeWidth =
+        getAttribute(attributes, 'stroke-width', def: null);
 
-    final String? anyStrokeAttribute = rawStroke ?? rawStrokeCap ?? rawLineJoin ?? rawMiterLimit ?? rawStrokeWidth;
+    final String? anyStrokeAttribute = rawStroke ??
+        rawStrokeCap ??
+        rawLineJoin ??
+        rawMiterLimit ??
+        rawStrokeWidth;
     if (anyStrokeAttribute == null && DrawablePaint.isEmpty(parentStroke)) {
       return null;
     } else if (rawStroke == 'none') {
@@ -1298,17 +1424,33 @@ class SvgParserState {
 
     final DrawablePaint paint = DrawablePaint(
       PaintingStyle.stroke,
-      color: (strokeColor ?? currentColor ?? parentStroke?.color ?? definitionPaint?.color)?.withOpacity(opacity),
+      color: (strokeColor ??
+              currentColor ??
+              parentStroke?.color ??
+              definitionPaint?.color)
+          ?.withOpacity(opacity),
       strokeCap: StrokeCap.values.firstWhere(
         (StrokeCap sc) => sc.toString() == 'StrokeCap.$rawStrokeCap',
-        orElse: () => parentStroke?.strokeCap ?? definitionPaint?.strokeCap ?? StrokeCap.butt,
+        orElse: () =>
+            parentStroke?.strokeCap ??
+            definitionPaint?.strokeCap ??
+            StrokeCap.butt,
       ),
       strokeJoin: StrokeJoin.values.firstWhere(
         (StrokeJoin sj) => sj.toString() == 'StrokeJoin.$rawLineJoin',
-        orElse: () => parentStroke?.strokeJoin ?? definitionPaint?.strokeJoin ?? StrokeJoin.miter,
+        orElse: () =>
+            parentStroke?.strokeJoin ??
+            definitionPaint?.strokeJoin ??
+            StrokeJoin.miter,
       ),
-      strokeMiterLimit: parseDouble(rawMiterLimit) ?? parentStroke?.strokeMiterLimit ?? definitionPaint?.strokeMiterLimit ?? 4.0,
-      strokeWidth: parseDoubleWithUnits(rawStrokeWidth) ?? parentStroke?.strokeWidth ?? definitionPaint?.strokeWidth ?? 1.0,
+      strokeMiterLimit: parseDouble(rawMiterLimit) ??
+          parentStroke?.strokeMiterLimit ??
+          definitionPaint?.strokeMiterLimit ??
+          4.0,
+      strokeWidth: parseDoubleWithUnits(rawStrokeWidth) ??
+          parentStroke?.strokeWidth ??
+          definitionPaint?.strokeWidth ??
+          1.0,
     );
 
     return DrawablePaint.merge(definitionPaint, paint);
@@ -1324,7 +1466,8 @@ class SvgParserState {
     Map<String, String> attributes,
   ) async {
     final String rawFill = getAttribute(attributes, 'fill', def: '')!;
-    final String? rawFillOpacity = getAttribute(attributes, 'fill-opacity', def: '1.0');
+    final String? rawFillOpacity =
+        getAttribute(attributes, 'fill-opacity', def: '1.0');
     final String? rawOpacity = getAttribute(attributes, 'opacity', def: '');
     double opacity = parseDouble(rawFillOpacity)!.clamp(0.0, 1.0).toDouble();
     if (rawOpacity != '') {
@@ -1352,7 +1495,8 @@ class SvgParserState {
       currentColor,
     );
 
-    if (rawFill == '' && (fillColor == null || parentFill == DrawablePaint.empty)) {
+    if (rawFill == '' &&
+        (fillColor == null || parentFill == DrawablePaint.empty)) {
       return null;
     }
     if (rawFill == 'none') {
@@ -1373,7 +1517,9 @@ class SvgParserState {
     Color? defaultFillColor,
     Color? currentColor,
   ) {
-    final Color? color = parseColor(rawFill, currentColor: currentColor) ?? parentFillColor ?? defaultFillColor;
+    final Color? color = parseColor(rawFill, currentColor: currentColor) ??
+        parentFillColor ??
+        defaultFillColor;
 
     if (explicitOpacity && color != null) {
       return color.withOpacity(opacity);
@@ -1394,7 +1540,8 @@ class SvgParserState {
 
   /// Applies a transform to a path if the [attributes] contain a `transform`.
   Path? applyTransformIfNeeded(Path? path, Map<String, String> attributes) {
-    final Matrix4? transform = parseTransform(getAttribute(attributes, 'transform', def: null));
+    final Matrix4? transform =
+        parseTransform(getAttribute(attributes, 'transform', def: null));
 
     if (transform != null) {
       return path!.transform(transform.storage);
@@ -1404,7 +1551,8 @@ class SvgParserState {
   }
 
   /// Parses a `clipPath` element into a list of [Path]s.
-  Future<List<Path>?> parseClipPath(Map<String, String> attributes, XmlStartElementEvent? event) async {
+  Future<List<Path>?> parseClipPath(
+      Map<String, String> attributes, XmlStartElementEvent? event) async {
     final String? rawClipAttribute = getAttribute(attributes, 'clip-path');
     if (rawClipAttribute?.isNotEmpty == true) {
       return _getClipPath(rawClipAttribute!, event);
@@ -1431,7 +1579,8 @@ class SvgParserState {
   };
 
   /// Lookup the mask if the attribute is present.
-  Future<DrawableStyleable?> parseMask(XmlStartElementEvent? event, Map<String, String> attributes) async {
+  Future<DrawableStyleable?> parseMask(
+      XmlStartElementEvent? event, Map<String, String> attributes) async {
     final String? rawMaskAttribute = getAttribute(attributes, 'mask');
     if (rawMaskAttribute != '') {
       return _getDrawable(rawMaskAttribute!, event);
@@ -1501,7 +1650,8 @@ class SvgParserState {
       case 'line-through':
         return TextDecoration.lineThrough;
     }
-    throw UnsupportedError('Attribute value for text-decoration="$textDecoration"'
+    throw UnsupportedError(
+        'Attribute value for text-decoration="$textDecoration"'
         ' is not supported');
   }
 
@@ -1522,7 +1672,8 @@ class SvgParserState {
       case 'wavy':
         return TextDecorationStyle.wavy;
     }
-    throw UnsupportedError('Attribute value for text-decoration-style="$textDecorationStyle"'
+    throw UnsupportedError(
+        'Attribute value for text-decoration-style="$textDecorationStyle"'
         ' is not supported');
   }
 
@@ -1539,10 +1690,12 @@ class SvgParserState {
     final XmlStartElementEvent? event = _currentStartElement;
     return DrawableStyle.mergeAndBlend(
       parentStyle,
-      stroke: await parseStroke(bounds, parentStyle?.stroke, currentColor, event, attributes),
+      stroke: await parseStroke(
+          bounds, parentStyle?.stroke, currentColor, event, attributes),
       dashArray: parseDashArray(attributes),
       dashOffset: parseDashOffset(attributes),
-      fill: await parseFill(bounds, parentStyle?.fill, defaultFillColor, currentColor, event, attributes),
+      fill: await parseFill(bounds, parentStyle?.fill, defaultFillColor,
+          currentColor, event, attributes),
       pathFillType: parseFillRule(
         attributes,
         'fill-rule',
@@ -1553,7 +1706,8 @@ class SvgParserState {
       clipPath: await parseClipPath(attributes, event),
       textStyle: DrawableTextStyle(
         fontFamily: getAttribute(attributes, 'font-family'),
-        fontSize: parseFontSize(getAttribute(attributes, 'font-size'), parentValue: parentStyle?.textStyle?.fontSize),
+        fontSize: parseFontSize(getAttribute(attributes, 'font-size'),
+            parentValue: parentStyle?.textStyle?.fontSize),
         fontWeight: parseFontWeight(
           getAttribute(attributes, 'font-weight', def: null),
         ),
@@ -1614,19 +1768,27 @@ class SvgParserState {
 
     // handle rgba() colors e.g. rgba(255, 255, 255, 1.0)
     if (colorString.toLowerCase().startsWith('rgba')) {
-      final List<String> rawColorElements =
-          colorString.substring(colorString.indexOf('(') + 1, colorString.indexOf(')')).split(',').map((String rawColor) => rawColor.trim()).toList();
+      final List<String> rawColorElements = colorString
+          .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
+          .split(',')
+          .map((String rawColor) => rawColor.trim())
+          .toList();
 
       final double opacity = parseDouble(rawColorElements.removeLast())!;
 
-      final List<int> rgb = rawColorElements.map((String rawColor) => int.parse(rawColor)).toList();
+      final List<int> rgb = rawColorElements
+          .map((String rawColor) => int.parse(rawColor))
+          .toList();
 
       return Color.fromRGBO(rgb[0], rgb[1], rgb[2], opacity);
     }
 
     // Conversion code from: https://github.com/MichaelFenwick/Color, thanks :)
     if (colorString.toLowerCase().startsWith('hsl')) {
-      final List<int> values = colorString.substring(colorString.indexOf('(') + 1, colorString.indexOf(')')).split(',').map((String rawColor) {
+      final List<int> values = colorString
+          .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
+          .split(',')
+          .map((String rawColor) {
         rawColor = rawColor.trim();
 
         if (rawColor.endsWith('%')) {
@@ -1665,22 +1827,30 @@ class SvgParserState {
         rgb[2] = 6 - hue * 6;
       }
 
-      rgb = rgb.map((double val) => val + (1 - saturation) * (0.5 - val)).toList();
+      rgb = rgb
+          .map((double val) => val + (1 - saturation) * (0.5 - val))
+          .toList();
 
       if (luminance < 0.5) {
         rgb = rgb.map((double val) => luminance * 2 * val).toList();
       } else {
-        rgb = rgb.map((double val) => luminance * 2 * (1 - val) + 2 * val - 1).toList();
+        rgb = rgb
+            .map((double val) => luminance * 2 * (1 - val) + 2 * val - 1)
+            .toList();
       }
 
       rgb = rgb.map((double val) => val * 255).toList();
 
-      return Color.fromARGB(alpha, rgb[0].round(), rgb[1].round(), rgb[2].round());
+      return Color.fromARGB(
+          alpha, rgb[0].round(), rgb[1].round(), rgb[2].round());
     }
 
     // handle rgb() colors e.g. rgb(255, 255, 255)
     if (colorString.toLowerCase().startsWith('rgb')) {
-      final List<int> rgb = colorString.substring(colorString.indexOf('(') + 1, colorString.indexOf(')')).split(',').map((String rawColor) {
+      final List<int> rgb = colorString
+          .substring(colorString.indexOf('(') + 1, colorString.indexOf(')'))
+          .split(',')
+          .map((String rawColor) {
         rawColor = rawColor.trim();
         if (rawColor.endsWith('%')) {
           rawColor = rawColor.substring(0, rawColor.length - 1);
@@ -1705,13 +1875,16 @@ class SvgParserState {
 
   void _completeProcessing(String? id, XmlStartElementEvent? currentElement) {
     _processing.remove(currentElement);
-    if (_processing.isEmpty && !_unknownDefinitions.keys.contains(_buildHref(id)) && _drawingCompleter != null) {
+    if (_processing.isEmpty &&
+        !_unknownDefinitions.keys.contains(_buildHref(id)) &&
+        _drawingCompleter != null) {
       // TODO(ikbendewilliam): remove Implicit check if _drawingCompleter != null
       _drawingCompleter!.complete();
     }
   }
 
-  Future<DrawableStyleable> _getDrawable(String xlinkHref, XmlStartElementEvent? event) async {
+  Future<DrawableStyleable> _getDrawable(
+      String xlinkHref, XmlStartElementEvent? event) async {
     DrawableStyleable? ref = _definitions.getDrawable('url($xlinkHref)');
     if (ref == null) {
       await _waitForRef(xlinkHref, event);
@@ -1720,7 +1893,8 @@ class SvgParserState {
     return ref!;
   }
 
-  Future<List<Path>> _getClipPath(String rawClipAttribute, XmlStartElementEvent? event) async {
+  Future<List<Path>> _getClipPath(
+      String rawClipAttribute, XmlStartElementEvent? event) async {
     List<Path>? ref = _definitions.getClipPath(rawClipAttribute);
     if (ref == null) {
       await _waitForRef(rawClipAttribute, event);
@@ -1729,8 +1903,10 @@ class SvgParserState {
     return ref!;
   }
 
-  Future<DrawableGradient> _getGradient(String xlinkHref, XmlStartElementEvent event) async {
-    DrawableGradient? ref = _definitions.getGradient<DrawableGradient>(xlinkHref);
+  Future<DrawableGradient> _getGradient(
+      String xlinkHref, XmlStartElementEvent event) async {
+    DrawableGradient? ref =
+        _definitions.getGradient<DrawableGradient>(xlinkHref);
     if (ref == null) {
       await _waitForRef(xlinkHref, event);
       ref = _definitions.getGradient(xlinkHref);
@@ -1738,7 +1914,8 @@ class SvgParserState {
     return ref!;
   }
 
-  Future<Shader> _getShader(String xlinkHref, Rect bounds, XmlStartElementEvent? event) async {
+  Future<Shader> _getShader(
+      String xlinkHref, Rect bounds, XmlStartElementEvent? event) async {
     Shader? ref = _definitions.getShader(xlinkHref, bounds);
     if (ref == null) {
       await _waitForRef(xlinkHref, event);

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -200,6 +200,7 @@ class _Elements {
       color: color,
     );
     parserState.addGroup(currentElement, group, id ?? '');
+    parserState._completeProcessing(id, currentElement);
   }
 
   static Future<void>? use(SvgParserState parserState,

--- a/lib/src/svg/parser_state.dart
+++ b/lib/src/svg/parser_state.dart
@@ -482,6 +482,8 @@ class _Elements {
       }
       if (event is XmlStartElementEvent) {
         final _PathFunc? pathFn = _svgPathFuncs[event.name];
+        final Map<String, String> attributes =
+            event.attributes.toAttributeMap();
 
         if (pathFn != null) {
           final Path nextPath = parserState.applyTransformIfNeeded(
@@ -534,7 +536,7 @@ class _Elements {
       }
     }
     parserState._definitions.addClipPath(id, paths);
-    parserState._markUnkownDefinitionComplete(parserState._buildHref(id));
+    parserState._markUnkownDefinitionComplete(id);
   }
 
   static Future<void> image(SvgParserState parserState,

--- a/lib/src/utilities/errors.dart
+++ b/lib/src/utilities/errors.dart
@@ -6,14 +6,8 @@ void reportMissingDef(String? key, String? href, String methodName) {
     FlutterErrorDetails(
       exception: FlutterError.fromParts(<DiagnosticsNode>[
         ErrorSummary('Failed to find definition for $href'),
-        ErrorDescription(
-            'This library only supports <defs> and xlink:href references that '
-            'are defined ahead of their references.'),
-        ErrorHint(
-            'This error can be caused when the desired definition is defined after the element '
-            'referring to it (e.g. at the end of the file), or defined in another file.'),
-        ErrorDescription(
-            'This error is treated as non-fatal, but your SVG file will likely not render as intended'),
+        ErrorHint('Could not find a definition for $href, check your SVG file if it is defined.'),
+        ErrorDescription('This error is treated as non-fatal, but your SVG file will likely not render as intended'),
       ]),
       context: ErrorDescription('while parsing $key in $methodName'),
       library: 'SVG',

--- a/lib/src/utilities/errors.dart
+++ b/lib/src/utilities/errors.dart
@@ -6,8 +6,10 @@ void reportMissingDef(String? key, String? href, String methodName) {
     FlutterErrorDetails(
       exception: FlutterError.fromParts(<DiagnosticsNode>[
         ErrorSummary('Failed to find definition for $href'),
-        ErrorHint('Could not find a definition for $href, check your SVG file if it is defined.'),
-        ErrorDescription('This error is treated as non-fatal, but your SVG file will likely not render as intended'),
+        ErrorHint(
+            'Could not find a definition for $href, check your SVG file if it is defined.'),
+        ErrorDescription(
+            'This error is treated as non-fatal, but your SVG file will likely not render as intended'),
       ]),
       context: ErrorDescription('while parsing $key in $methodName'),
       library: 'SVG',

--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -22,18 +22,21 @@ String? getAttribute(
   String name, {
   String? def = '',
   bool checkStyle = true,
+  bool useRegexp = false,
 }) {
   String raw = '';
   if (checkStyle) {
     final String? style = _getAttribute(el, 'style');
     if (style != '' && style != null) {
-      // Probably possible to slightly optimize this (e.g. use indexOf instead of split),
-      // but handling potential whitespace will get complicated and this just works.
-      // I also don't feel like writing benchmarks for what is likely a micro-optimization.
+      // We could do this, but split is a tiny bit faster:
+      // final int attributeIndex = style.indexOf(RegExp('(^|;)\s*$name\s*:'));
+      // if (attributeIndex != -1) {
+      //   final int endIndex = style.indexOf(';', attributeIndex + 1);
+      //   final String attribute = style.substring(attributeIndex + 1, endIndex == -1 ? null : endIndex);
+      //   raw = attribute.substring(attribute.indexOf(':') + 1).trim();
+      // }
       final List<String> styles = style.split(';');
-      raw = styles.firstWhere(
-          (String str) => str.trimLeft().startsWith(name + ':'),
-          orElse: () => '');
+      raw = styles.firstWhere((String str) => str.trimLeft().startsWith(name + ':'), orElse: () => '');
 
       if (raw != '') {
         raw = raw.substring(raw.indexOf(':') + 1).trim();
@@ -63,7 +66,6 @@ String _getAttribute(
 extension AttributeMapXmlEventAttributeExtension on List<XmlEventAttribute> {
   /// Converts the List<XmlEventAttribute> to an attribute map.
   Map<String, String> toAttributeMap() => <String, String>{
-        for (final XmlEventAttribute attribute in this)
-          attribute.localName: attribute.value.trim(),
+        for (final XmlEventAttribute attribute in this) attribute.localName: attribute.value.trim(),
       };
 }

--- a/lib/src/utilities/xml.dart
+++ b/lib/src/utilities/xml.dart
@@ -36,7 +36,9 @@ String? getAttribute(
       //   raw = attribute.substring(attribute.indexOf(':') + 1).trim();
       // }
       final List<String> styles = style.split(';');
-      raw = styles.firstWhere((String str) => str.trimLeft().startsWith(name + ':'), orElse: () => '');
+      raw = styles.firstWhere(
+          (String str) => str.trimLeft().startsWith(name + ':'),
+          orElse: () => '');
 
       if (raw != '') {
         raw = raw.substring(raw.indexOf(':') + 1).trim();
@@ -66,6 +68,7 @@ String _getAttribute(
 extension AttributeMapXmlEventAttributeExtension on List<XmlEventAttribute> {
   /// Converts the List<XmlEventAttribute> to an attribute map.
   Map<String, String> toAttributeMap() => <String, String>{
-        for (final XmlEventAttribute attribute in this) attribute.localName: attribute.value.trim(),
+        for (final XmlEventAttribute attribute in this)
+          attribute.localName: attribute.value.trim(),
       };
 }

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -85,7 +85,8 @@ class DrawableStyle {
   ///
   /// This will not result in a drawing operation, but will clear out
   /// inheritance.
-  static final CircularIntervalList<double> emptyDashArray = CircularIntervalList<double>(const <double>[]);
+  static final CircularIntervalList<double> emptyDashArray =
+      CircularIntervalList<double>(const <double>[]);
 
   /// If not `null` and not `identical` with [DrawablePaint.empty], will result in a stroke
   /// for the rendered [DrawableShape]. Drawn __after__ the [fill].
@@ -193,7 +194,8 @@ class DrawablePaint {
       return a;
     }
 
-    if (identical(a, DrawablePaint.empty) || identical(b, DrawablePaint.empty)) {
+    if (identical(a, DrawablePaint.empty) ||
+        identical(b, DrawablePaint.empty)) {
       return a ?? b;
     }
 
@@ -202,7 +204,8 @@ class DrawablePaint {
     }
 
     // If we got here, the styles should not be null.
-    assert(a.style == b!.style, 'Cannot merge Paints with different PaintStyles; got:\na: $a\nb: $b.');
+    assert(a.style == b!.style,
+        'Cannot merge Paints with different PaintStyles; got:\na: $a\nb: $b.');
 
     b = b!;
     return DrawablePaint(
@@ -445,12 +448,14 @@ class DrawableTextStyle {
       height: height,
       locale: locale,
       background: background?.toFlutterPaint(),
-      foreground: foregroundOverride?.toFlutterPaint() ?? foreground?.toFlutterPaint(),
+      foreground:
+          foregroundOverride?.toFlutterPaint() ?? foreground?.toFlutterPaint(),
     );
   }
 
   @override
-  String toString() => 'DrawableTextStyle{$decoration,$decorationColor,$decorationStyle,$fontWeight,'
+  String toString() =>
+      'DrawableTextStyle{$decoration,$decorationColor,$decorationStyle,$fontWeight,'
       '$fontFamily,$fontSize,$fontStyle,$foreground,$background,$letterSpacing,$wordSpacing,$height,'
       '$locale,$textBaseline,$anchor}';
 }
@@ -502,7 +507,8 @@ class DrawableText implements Drawable {
   final Float64List? transform;
 
   @override
-  bool get hasDrawableContent => (fill?.width ?? 0.0) + (stroke?.width ?? 0.0) > 0.0;
+  bool get hasDrawableContent =>
+      (fill?.width ?? 0.0) + (stroke?.width ?? 0.0) > 0.0;
 
   @override
   void draw(Canvas canvas, Rect bounds) {
@@ -557,13 +563,15 @@ class DrawableText implements Drawable {
 class DrawableDefinitionServer {
   final Map<String, DrawableGradient> _gradients = <String, DrawableGradient>{};
   final Map<String, List<Path>> _clipPaths = <String, List<Path>>{};
-  final Map<String, DrawableStyleable> _drawables = <String, DrawableStyleable>{};
+  final Map<String, DrawableStyleable> _drawables =
+      <String, DrawableStyleable>{};
 
   /// An empty IRI for SVGs.
   static const String emptyUrlIri = 'url(#)';
 
   /// Attempt to lookup a [Drawable] by [id].
-  DrawableStyleable? getDrawable(String id, {bool nullOk = false}) => _drawables[id];
+  DrawableStyleable? getDrawable(String id, {bool nullOk = false}) =>
+      _drawables[id];
 
   /// Add a [Drawable] that can later be referred to by [id].
   void addDrawable(String id, DrawableStyleable drawable) {
@@ -572,13 +580,16 @@ class DrawableDefinitionServer {
   }
 
   /// Attempt to lookup a pre-defined [Shader] by [id].
-  Shader? getShader(String id, Rect bounds) => _gradients[id]?.createShader(bounds);
+  Shader? getShader(String id, Rect bounds) =>
+      _gradients[id]?.createShader(bounds);
 
   /// Retreive a gradient from the pre-defined [DrawableGradient] collection.
-  T? getGradient<T extends DrawableGradient?>(String id) => _gradients[id] as T?;
+  T? getGradient<T extends DrawableGradient?>(String id) =>
+      _gradients[id] as T?;
 
   /// Add a [DrawableGradient] to the pre-defined collection by [id].
-  void addGradient(String id, DrawableGradient gradient) => _gradients[id] = gradient;
+  void addGradient(String id, DrawableGradient gradient) =>
+      _gradients[id] = gradient;
 
   /// Get a [List<Path>] of clip paths by [id].
   List<Path>? getClipPath(String id) => _clipPaths[id];
@@ -657,13 +668,18 @@ class DrawableLinearGradient extends DrawableGradient {
 
   @override
   Shader createShader(Rect bounds) {
-    final bool isObjectBoundingBox = unitMode == GradientUnitMode.objectBoundingBox;
+    final bool isObjectBoundingBox =
+        unitMode == GradientUnitMode.objectBoundingBox;
 
-    Matrix4 m4transform = transform == null ? Matrix4.identity() : Matrix4.fromFloat64List(transform!);
+    Matrix4 m4transform = transform == null
+        ? Matrix4.identity()
+        : Matrix4.fromFloat64List(transform!);
 
     if (isObjectBoundingBox) {
-      final Matrix4 scale = affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
-      final Matrix4 translate = affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
+      final Matrix4 scale =
+          affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
+      final Matrix4 translate =
+          affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
       m4transform = translate.multiplied(scale)..multiply(m4transform);
     }
 
@@ -728,13 +744,18 @@ class DrawableRadialGradient extends DrawableGradient {
 
   @override
   Shader createShader(Rect bounds) {
-    final bool isObjectBoundingBox = unitMode == GradientUnitMode.objectBoundingBox;
+    final bool isObjectBoundingBox =
+        unitMode == GradientUnitMode.objectBoundingBox;
 
-    Matrix4 m4transform = transform == null ? Matrix4.identity() : Matrix4.fromFloat64List(transform!);
+    Matrix4 m4transform = transform == null
+        ? Matrix4.identity()
+        : Matrix4.fromFloat64List(transform!);
 
     if (isObjectBoundingBox) {
-      final Matrix4 scale = affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
-      final Matrix4 translate = affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
+      final Matrix4 scale =
+          affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
+      final Matrix4 translate =
+          affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
       m4transform = translate.multiplied(scale)..multiply(m4transform);
     }
 
@@ -870,7 +891,8 @@ class DrawableRoot implements DrawableParent {
   }
 
   @override
-  bool get hasDrawableContent => children.isNotEmpty == true && !viewport.viewBox.isEmpty;
+  bool get hasDrawableContent =>
+      children.isNotEmpty == true && !viewport.viewBox.isEmpty;
 
   /// Draws the contents or children of this [Drawable] to the `canvas`, using
   /// the `parentPaint` to optionally override the child's paint.
@@ -946,7 +968,8 @@ class DrawableRoot implements DrawableParent {
       textStyle: newStyle.textStyle,
     );
 
-    final List<Drawable> mergedChildren = children.map<Drawable>((Drawable child) {
+    final List<Drawable> mergedChildren =
+        children.map<Drawable>((Drawable child) {
       if (child is DrawableStyleable) {
         return child.mergeStyle(mergedStyle);
       }
@@ -1071,7 +1094,8 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
       textStyle: newStyle.textStyle,
     );
 
-    final List<Drawable> mergedChildren = children!.map<Drawable>((Drawable child) {
+    final List<Drawable> mergedChildren =
+        children!.map<Drawable>((Drawable child) {
       if (child is DrawableStyleable) {
         return child.mergeStyle(mergedStyle);
       }
@@ -1231,7 +1255,8 @@ class DrawableShape implements DrawableStyleable {
 
       if (style.stroke?.color != null) {
         assert(style.stroke!.style == PaintingStyle.stroke);
-        if (style.dashArray != null && !identical(style.dashArray, DrawableStyle.emptyDashArray)) {
+        if (style.dashArray != null &&
+            !identical(style.dashArray, DrawableStyle.emptyDashArray)) {
           canvas.drawPath(
             dashPath(
               path,

--- a/lib/src/vector_drawable.dart
+++ b/lib/src/vector_drawable.dart
@@ -85,8 +85,7 @@ class DrawableStyle {
   ///
   /// This will not result in a drawing operation, but will clear out
   /// inheritance.
-  static final CircularIntervalList<double> emptyDashArray =
-      CircularIntervalList<double>(const <double>[]);
+  static final CircularIntervalList<double> emptyDashArray = CircularIntervalList<double>(const <double>[]);
 
   /// If not `null` and not `identical` with [DrawablePaint.empty], will result in a stroke
   /// for the rendered [DrawableShape]. Drawn __after__ the [fill].
@@ -194,8 +193,7 @@ class DrawablePaint {
       return a;
     }
 
-    if (identical(a, DrawablePaint.empty) ||
-        identical(b, DrawablePaint.empty)) {
+    if (identical(a, DrawablePaint.empty) || identical(b, DrawablePaint.empty)) {
       return a ?? b;
     }
 
@@ -204,8 +202,7 @@ class DrawablePaint {
     }
 
     // If we got here, the styles should not be null.
-    assert(a.style == b!.style,
-        'Cannot merge Paints with different PaintStyles; got:\na: $a\nb: $b.');
+    assert(a.style == b!.style, 'Cannot merge Paints with different PaintStyles; got:\na: $a\nb: $b.');
 
     b = b!;
     return DrawablePaint(
@@ -448,14 +445,12 @@ class DrawableTextStyle {
       height: height,
       locale: locale,
       background: background?.toFlutterPaint(),
-      foreground:
-          foregroundOverride?.toFlutterPaint() ?? foreground?.toFlutterPaint(),
+      foreground: foregroundOverride?.toFlutterPaint() ?? foreground?.toFlutterPaint(),
     );
   }
 
   @override
-  String toString() =>
-      'DrawableTextStyle{$decoration,$decorationColor,$decorationStyle,$fontWeight,'
+  String toString() => 'DrawableTextStyle{$decoration,$decorationColor,$decorationStyle,$fontWeight,'
       '$fontFamily,$fontSize,$fontStyle,$foreground,$background,$letterSpacing,$wordSpacing,$height,'
       '$locale,$textBaseline,$anchor}';
 }
@@ -507,8 +502,7 @@ class DrawableText implements Drawable {
   final Float64List? transform;
 
   @override
-  bool get hasDrawableContent =>
-      (fill?.width ?? 0.0) + (stroke?.width ?? 0.0) > 0.0;
+  bool get hasDrawableContent => (fill?.width ?? 0.0) + (stroke?.width ?? 0.0) > 0.0;
 
   @override
   void draw(Canvas canvas, Rect bounds) {
@@ -537,9 +531,6 @@ class DrawableText implements Drawable {
     DrawableTextAnchorPosition anchor,
     Offset offset,
   ) {
-    assert(paragraph != null); // ignore: unnecessary_null_comparison
-    assert(anchor != null); // ignore: unnecessary_null_comparison
-    assert(offset != null); // ignore: unnecessary_null_comparison
     switch (anchor) {
       case DrawableTextAnchorPosition.middle:
         return Offset(
@@ -566,66 +557,34 @@ class DrawableText implements Drawable {
 class DrawableDefinitionServer {
   final Map<String, DrawableGradient> _gradients = <String, DrawableGradient>{};
   final Map<String, List<Path>> _clipPaths = <String, List<Path>>{};
-  final Map<String, DrawableStyleable> _drawables =
-      <String, DrawableStyleable>{};
+  final Map<String, DrawableStyleable> _drawables = <String, DrawableStyleable>{};
 
   /// An empty IRI for SVGs.
   static const String emptyUrlIri = 'url(#)';
 
   /// Attempt to lookup a [Drawable] by [id].
-  DrawableStyleable? getDrawable(String id, {bool nullOk = false}) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    final DrawableStyleable? value = _drawables[id];
-    if (value == null && nullOk != true) {
-      throw StateError('Expected to find Drawable with id $id.\n'
-          'Have ids: ${_drawables.keys}');
-    }
-    return value;
-  }
+  DrawableStyleable? getDrawable(String id, {bool nullOk = false}) => _drawables[id];
 
   /// Add a [Drawable] that can later be referred to by [id].
   void addDrawable(String id, DrawableStyleable drawable) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    assert(drawable != null); // ignore: unnecessary_null_comparison
     assert(id != emptyUrlIri);
     _drawables[id] = drawable;
   }
 
   /// Attempt to lookup a pre-defined [Shader] by [id].
-  ///
-  /// [id] and [bounds] must not be null.
-  Shader? getShader(String id, Rect bounds) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    assert(bounds != null); // ignore: unnecessary_null_comparison
-    final DrawableGradient? srv = _gradients[id];
-    return srv != null ? srv.createShader(bounds) : null;
-  }
+  Shader? getShader(String id, Rect bounds) => _gradients[id]?.createShader(bounds);
 
   /// Retreive a gradient from the pre-defined [DrawableGradient] collection.
-  T? getGradient<T extends DrawableGradient?>(String id) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    return _gradients[id] as T?;
-  }
+  T? getGradient<T extends DrawableGradient?>(String id) => _gradients[id] as T?;
 
   /// Add a [DrawableGradient] to the pre-defined collection by [id].
-  void addGradient(String id, DrawableGradient gradient) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    assert(gradient != null); // ignore: unnecessary_null_comparison
-    _gradients[id] = gradient;
-  }
+  void addGradient(String id, DrawableGradient gradient) => _gradients[id] = gradient;
 
   /// Get a [List<Path>] of clip paths by [id].
-  List<Path>? getClipPath(String id) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    return _clipPaths[id];
-  }
+  List<Path>? getClipPath(String id) => _clipPaths[id];
 
   /// Add a [List<Path>] of clip paths by [id].
-  void addClipPath(String id, List<Path> paths) {
-    assert(id != null); // ignore: unnecessary_null_comparison
-    assert(paths != null); // ignore: unnecessary_null_comparison
-    _clipPaths[id] = paths;
-  }
+  void addClipPath(String id, List<Path> paths) => _clipPaths[id] = paths;
 }
 
 /// Determines how to transform the points given for a gradient.
@@ -698,18 +657,13 @@ class DrawableLinearGradient extends DrawableGradient {
 
   @override
   Shader createShader(Rect bounds) {
-    final bool isObjectBoundingBox =
-        unitMode == GradientUnitMode.objectBoundingBox;
+    final bool isObjectBoundingBox = unitMode == GradientUnitMode.objectBoundingBox;
 
-    Matrix4 m4transform = transform == null
-        ? Matrix4.identity()
-        : Matrix4.fromFloat64List(transform!);
+    Matrix4 m4transform = transform == null ? Matrix4.identity() : Matrix4.fromFloat64List(transform!);
 
     if (isObjectBoundingBox) {
-      final Matrix4 scale =
-          affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
-      final Matrix4 translate =
-          affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
+      final Matrix4 scale = affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
+      final Matrix4 translate = affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
       m4transform = translate.multiplied(scale)..multiply(m4transform);
     }
 
@@ -774,18 +728,13 @@ class DrawableRadialGradient extends DrawableGradient {
 
   @override
   Shader createShader(Rect bounds) {
-    final bool isObjectBoundingBox =
-        unitMode == GradientUnitMode.objectBoundingBox;
+    final bool isObjectBoundingBox = unitMode == GradientUnitMode.objectBoundingBox;
 
-    Matrix4 m4transform = transform == null
-        ? Matrix4.identity()
-        : Matrix4.fromFloat64List(transform!);
+    Matrix4 m4transform = transform == null ? Matrix4.identity() : Matrix4.fromFloat64List(transform!);
 
     if (isObjectBoundingBox) {
-      final Matrix4 scale =
-          affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
-      final Matrix4 translate =
-          affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
+      final Matrix4 scale = affineMatrix(bounds.width, 0.0, 0.0, bounds.height, 0.0, 0.0);
+      final Matrix4 translate = affineMatrix(1.0, 0.0, 0.0, 1.0, bounds.left, bounds.top);
       m4transform = translate.multiplied(scale)..multiply(m4transform);
     }
 
@@ -813,9 +762,7 @@ class DrawableViewport {
     this.size,
     this.viewBox, {
     this.viewBoxOffset = Offset.zero,
-  })  : assert(size != null), // ignore: unnecessary_null_comparison
-        assert(viewBox != null), // ignore: unnecessary_null_comparison
-        assert(viewBoxOffset != null); // ignore: unnecessary_null_comparison
+  });
 
   /// The offset for all drawing commands in this Drawable.
   final Offset viewBoxOffset;
@@ -827,8 +774,6 @@ class DrawableViewport {
   final Size viewBox;
 
   /// The viewport size of the drawable.
-  ///
-  /// This may or may not be identical to the
   final Size size;
 
   /// The width of the viewport rect.
@@ -925,8 +870,7 @@ class DrawableRoot implements DrawableParent {
   }
 
   @override
-  bool get hasDrawableContent =>
-      children.isNotEmpty == true && !viewport.viewBox.isEmpty;
+  bool get hasDrawableContent => children.isNotEmpty == true && !viewport.viewBox.isEmpty;
 
   /// Draws the contents or children of this [Drawable] to the `canvas`, using
   /// the `parentPaint` to optionally override the child's paint.
@@ -990,7 +934,6 @@ class DrawableRoot implements DrawableParent {
 
   @override
   DrawableRoot mergeStyle(DrawableStyle newStyle) {
-    assert(newStyle != null); // ignore: unnecessary_null_comparison
     final DrawableStyle mergedStyle = DrawableStyle.mergeAndBlend(
       style,
       fill: newStyle.fill,
@@ -1003,8 +946,7 @@ class DrawableRoot implements DrawableParent {
       textStyle: newStyle.textStyle,
     );
 
-    final List<Drawable> mergedChildren =
-        children.map<Drawable>((Drawable child) {
+    final List<Drawable> mergedChildren = children.map<Drawable>((Drawable child) {
       if (child is DrawableStyleable) {
         return child.mergeStyle(mergedStyle);
       }
@@ -1118,7 +1060,6 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
 
   @override
   DrawableGroup mergeStyle(DrawableStyle newStyle) {
-    assert(newStyle != null); // ignore: unnecessary_null_comparison
     final DrawableStyle mergedStyle = DrawableStyle.mergeAndBlend(
       style,
       fill: newStyle.fill,
@@ -1130,8 +1071,7 @@ class DrawableGroup implements DrawableStyleable, DrawableParent {
       textStyle: newStyle.textStyle,
     );
 
-    final List<Drawable> mergedChildren =
-        children!.map<Drawable>((Drawable child) {
+    final List<Drawable> mergedChildren = children!.map<Drawable>((Drawable child) {
       if (child is DrawableStyleable) {
         return child.mergeStyle(mergedStyle);
       }
@@ -1157,8 +1097,7 @@ class DrawableRasterImage implements DrawableStyleable {
     this.style, {
     this.size,
     this.transform,
-  })  : assert(image != null), // ignore: unnecessary_null_comparison
-        assert(offset != null); // ignore: unnecessary_null_comparison
+  });
 
   @override
   final String? id;
@@ -1218,7 +1157,6 @@ class DrawableRasterImage implements DrawableStyleable {
 
   @override
   DrawableRasterImage mergeStyle(DrawableStyle newStyle) {
-    assert(newStyle != null); // ignore: unnecessary_null_comparison
     return DrawableRasterImage(
       id,
       image,
@@ -1243,9 +1181,7 @@ class DrawableRasterImage implements DrawableStyleable {
 /// Represents a drawing element that will be rendered to the canvas.
 class DrawableShape implements DrawableStyleable {
   /// Creates a new [DrawableShape].
-  const DrawableShape(this.id, this.path, this.style, {this.transform})
-      : assert(path != null), // ignore: unnecessary_null_comparison
-        assert(style != null); // ignore: unnecessary_null_comparison
+  const DrawableShape(this.id, this.path, this.style, {this.transform});
 
   @override
   final String? id;
@@ -1295,8 +1231,7 @@ class DrawableShape implements DrawableStyleable {
 
       if (style.stroke?.color != null) {
         assert(style.stroke!.style == PaintingStyle.stroke);
-        if (style.dashArray != null &&
-            !identical(style.dashArray, DrawableStyle.emptyDashArray)) {
+        if (style.dashArray != null && !identical(style.dashArray, DrawableStyle.emptyDashArray)) {
           canvas.drawPath(
             dashPath(
               path,
@@ -1338,23 +1273,20 @@ class DrawableShape implements DrawableStyleable {
   }
 
   @override
-  DrawableShape mergeStyle(DrawableStyle newStyle) {
-    assert(newStyle != null); // ignore: unnecessary_null_comparison
-    return DrawableShape(
-      id,
-      path,
-      DrawableStyle.mergeAndBlend(
-        style,
-        fill: newStyle.fill,
-        stroke: newStyle.stroke,
-        clipPath: newStyle.clipPath,
-        mask: newStyle.mask,
-        dashArray: newStyle.dashArray,
-        dashOffset: newStyle.dashOffset,
-        pathFillType: newStyle.pathFillType,
-        textStyle: newStyle.textStyle,
-      ),
-      transform: transform,
-    );
-  }
+  DrawableShape mergeStyle(DrawableStyle newStyle) => DrawableShape(
+        id,
+        path,
+        DrawableStyle.mergeAndBlend(
+          style,
+          fill: newStyle.fill,
+          stroke: newStyle.stroke,
+          clipPath: newStyle.clipPath,
+          mask: newStyle.mask,
+          dashArray: newStyle.dashArray,
+          dashOffset: newStyle.dashOffset,
+          pathFillType: newStyle.pathFillType,
+          textStyle: newStyle.textStyle,
+        ),
+        transform: transform,
+      );
 }

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -780,8 +780,9 @@ class _SvgPictureState extends State<SvgPicture> {
     final SvgTheme? defaultSvgTheme = DefaultSvgTheme.of(context)?.theme;
     final TextStyle defaultTextStyle = DefaultTextStyle.of(context).style;
 
-    final Color currentColor =
-        widget.theme?.currentColor ?? defaultSvgTheme?.currentColor ?? const Color(0xFF000000);
+    final Color currentColor = widget.theme?.currentColor ??
+        defaultSvgTheme?.currentColor ??
+        const Color(0xFF000000);
 
     final double fontSize = widget.theme?.fontSize ??
         defaultSvgTheme?.fontSize ??

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -27,7 +27,8 @@ void main() {
     FlutterError.onError = oldHandler;
   });
 
-  testWidgets('Report tag not found with valid tags afterward', (WidgetTester tester) async {
+  testWidgets('Report tag not found with valid tags afterward',
+      (WidgetTester tester) async {
     final FlutterExceptionHandler oldHandler = FlutterError.onError!;
     late FlutterErrorDetails error;
     FlutterError.onError = (FlutterErrorDetails details) {

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -27,6 +27,33 @@ void main() {
     FlutterError.onError = oldHandler;
   });
 
+  testWidgets('Report tag not found with valid tags afterward', (WidgetTester tester) async {
+    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
+    late FlutterErrorDetails error;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      error = details;
+    };
+
+    const String svgStr = '''
+<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+  <path id="path1" d="M79.5 170.7 120.9 156.4 107.4 142.8" />
+  <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
+  <path id="path2" d="M79.5 170.7 120.9 156.4 107.4 142.8" />
+  <path id="path3" d="M79.5 170.7 120.9 156.4 107.4 142.8" />
+</svg>
+''';
+    final SvgParser parser = SvgParser();
+    await parser.parse(
+      svgStr,
+      key: 'some_svg.svg',
+    );
+    expect(
+      error.context.toString(),
+      contains('while parsing some_svg.svg in parse'),
+    );
+    FlutterError.onError = oldHandler;
+  });
+
   testWidgets('Don\'t report tag out of order', (WidgetTester tester) async {
     final FlutterExceptionHandler oldHandler = FlutterError.onError!;
     FlutterErrorDetails? error;

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -1,9 +1,15 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_svg/parser.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Report tag not found', (WidgetTester tester) async {
-    // TODO(ikbendewilliam): check for error
+    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
+    late FlutterErrorDetails error;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      error = details;
+    };
+
     const String svgStr = '''
 <svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
   <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
@@ -14,5 +20,40 @@ void main() {
       svgStr,
       key: 'some_svg.svg',
     );
+    expect(
+      error.context.toString(),
+      contains('while parsing some_svg.svg in parse'),
+    );
+    FlutterError.onError = oldHandler;
+  });
+
+  testWidgets('Don\'t report tag out of order', (WidgetTester tester) async {
+    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
+    FlutterErrorDetails? error;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      error = details;
+    };
+
+    const String svgStr = '''
+<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+  <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
+  <defs>
+    <linearGradient id="triangleGradient">
+      <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
+      <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+    </linearGradient>
+  </defs>
+</svg>
+''';
+    final SvgParser parser = SvgParser();
+    await parser.parse(
+      svgStr,
+      key: 'some_svg.svg',
+    );
+    expect(
+      error,
+      isNull,
+    );
+    FlutterError.onError = oldHandler;
   });
 }

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -1,15 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_svg/parser.dart';
-
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Reports tag in out of order defs', (WidgetTester tester) async {
-    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
-    late FlutterErrorDetails error;
-    FlutterError.onError = (FlutterErrorDetails details) {
-      error = details;
-    };
+  testWidgets('Don\'t Report tag in out of order defs', (WidgetTester tester) async {
     const String svgStr = '''
 <svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
   <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
@@ -27,11 +20,5 @@ void main() {
       svgStr,
       key: 'some_svg.svg',
     );
-
-    expect(
-      error.context.toString(),
-      contains('while parsing some_svg.svg in _getDefinitionPaint'),
-    );
-    FlutterError.onError = oldHandler;
   });
 }

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -2,19 +2,13 @@ import 'package:flutter_svg/parser.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Don\'t Report tag in out of order defs', (WidgetTester tester) async {
+  testWidgets('Report tag not found', (WidgetTester tester) async {
+    // TODO(ikbendewilliam): check for error
     const String svgStr = '''
 <svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
   <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
-  <defs>
-    <linearGradient id="triangleGradient">
-      <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
-      <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
-    </linearGradient>
-  </defs>
 </svg>
 ''';
-
     final SvgParser parser = SvgParser();
     await parser.parse(
       svgStr,

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -15,16 +15,11 @@ void main() {
     expected.translate(0.338957, 0.010104, 0);
     expected.translate(-0.5214, 0.125, 0);
     expected.translate(0.987, 0.789, 0);
-    expect(
-        parseTransform(
-            'translate(0.338957,0.010104), translate(-0.5214,0.125),translate(0.987,0.789)'),
-        expected);
+    expect(parseTransform('translate(0.338957,0.010104), translate(-0.5214,0.125),translate(0.987,0.789)'), expected);
 
     expected = Matrix4.translationValues(0.338957, 0.010104, 0);
     expected.scale(0.869768, 1.000000, 1.0);
-    expect(
-        parseTransform('translate(0.338957,0.010104),scale(0.869768,1.000000)'),
-        expected);
+    expect(parseTransform('translate(0.338957,0.010104),scale(0.869768,1.000000)'), expected);
   });
 
   test('SVG Transform parser tests', () {
@@ -33,14 +28,11 @@ void main() {
 
     expect(parseTransform('skewX(60)'), Matrix4.skewX(60.0));
     expect(parseTransform('skewY(60)'), Matrix4.skewY(60.0));
-    expect(parseTransform('translate(10,0.0)'),
-        Matrix4.translationValues(10.0, 0.0, 0.0));
+    expect(parseTransform('translate(10,0.0)'), Matrix4.translationValues(10.0, 0.0, 0.0));
     expect(parseTransform('skewX(60)'), Matrix4.skewX(60.0));
 
-    expect(parseTransform('scale(10)'),
-        Matrix4.identity()..scale(10.0, 10.0, 1.0));
-    expect(parseTransform('scale(10, 15)'),
-        Matrix4.identity()..scale(10.0, 15.0, 1.0));
+    expect(parseTransform('scale(10)'), Matrix4.identity()..scale(10.0, 10.0, 1.0));
+    expect(parseTransform('scale(10, 15)'), Matrix4.identity()..scale(10.0, 15.0, 1.0));
 
     expect(parseTransform('rotate(20)'), Matrix4.rotationZ(radians(20.0)));
     expect(
@@ -74,8 +66,7 @@ void main() {
           5.0, 6.0, 0.0, 1.0
         ]));
 
-    expect(parseTransform('rotate(20)\n\tscale(10)'),
-        Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
+    expect(parseTransform('rotate(20)\n\tscale(10)'), Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
   });
 
   test('FillRule tests', () {
@@ -196,8 +187,7 @@ void main() {
       ),
     );
 
-    expect(() => parserState.parseFontSize('invalid'),
-        throwsA(const TypeMatcher<StateError>()));
+    expect(() => parserState.parseFontSize('invalid'), throwsA(const TypeMatcher<StateError>()));
   });
 
   test('relative font size tests', () {
@@ -250,8 +240,7 @@ void main() {
   });
 
   test('Check any ids', () async {
-    const String svgStr =
-        '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <defs>
         <linearGradient id="triangleGradient">
             <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
@@ -312,8 +301,7 @@ void main() {
     expect(find<DrawableShape>(root, 'Oval') != null, true);
   });
 
-  test('Throws with unsupported elements with warnings as errors enabled',
-      () async {
+  test('Throws with unsupported elements with warnings as errors enabled', () async {
     const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
 <svg width="27px" height="90px" viewBox="5 10 18 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
@@ -589,8 +577,7 @@ void main() {
           ),
         );
 
-        final DrawableLinearGradient? gradient =
-            root.definitions.getGradient('url(#gradient-1)');
+        final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient-1)');
 
         expect(gradient, isNotNull);
 
@@ -630,8 +617,7 @@ void main() {
           ),
         );
 
-        final DrawableLinearGradient? gradient =
-            root.definitions.getGradient('url(#gradient-1)');
+        final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient-1)');
 
         expect(gradient, isNotNull);
 
@@ -671,8 +657,7 @@ void main() {
           ),
         );
 
-        final DrawableLinearGradient? gradient =
-            root.definitions.getGradient('url(#gradient-1)');
+        final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient-1)');
 
         expect(gradient, isNotNull);
 
@@ -784,8 +769,7 @@ void main() {
         ),
       );
 
-      final DrawableRadialGradient? gradient =
-          root.definitions.getGradient('url(#gradient)');
+      final DrawableRadialGradient? gradient = root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -819,8 +803,7 @@ void main() {
         ),
       );
 
-      final DrawableLinearGradient? gradient =
-          root.definitions.getGradient('url(#gradient)');
+      final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -850,8 +833,7 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1em" y="0.5em" width="2em" height="1.5em" /
         ),
       );
 
-      final DrawableRasterImage? image =
-          find<DrawableRasterImage>(root, 'image');
+      final DrawableRasterImage? image = find<DrawableRasterImage>(root, 'image');
 
       const Offset expectedOffset = Offset(fontSize * 1, fontSize * 0.5);
       const Size expectedSize = Size(fontSize * 2, fontSize * 1.5);
@@ -965,8 +947,7 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1em" y="0.5em" width="2em" height="1.5em" /
         ),
       );
 
-      final DrawableRadialGradient? gradient =
-          root.definitions.getGradient('url(#gradient)');
+      final DrawableRadialGradient? gradient = root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -1002,8 +983,7 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1em" y="0.5em" width="2em" height="1.5em" /
         ),
       );
 
-      final DrawableLinearGradient? gradient =
-          root.definitions.getGradient('url(#gradient)');
+      final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -1035,8 +1015,7 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
         ),
       );
 
-      final DrawableRasterImage? image =
-          find<DrawableRasterImage>(root, 'image');
+      final DrawableRasterImage? image = find<DrawableRasterImage>(root, 'image');
 
       const Offset expectedOffset = Offset(xHeight * 1, xHeight * 0.5);
       const Size expectedSize = Size(xHeight * 2, xHeight * 1.5);

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -264,11 +264,11 @@ void main() {
     final DrawableRoot root = await parser.parse(svgStr);
 
     expect(root.id == 'svgRoot', true);
-    expect(find<DrawableGroup>(root, 'group1') != null, true);
-    expect(find<DrawableShape>(root, 'path1') != null, true);
-    expect(find<DrawableShape>(root, 'path2') != null, true);
-    expect(find<DrawableShape>(root, 'path3') != null, true);
-    expect(find<DrawableShape>(root, 'path4') != null, true);
+    expect(find<DrawableGroup>(root, 'group1'), isNotNull);
+    expect(find<DrawableShape>(root, 'path1'), isNotNull);
+    expect(find<DrawableShape>(root, 'path2'), isNotNull);
+    expect(find<DrawableShape>(root, 'path3'), isNotNull);
+    expect(find<DrawableShape>(root, 'path4'), isNotNull);
   });
 
   test('Check No Svg id', () async {
@@ -295,10 +295,10 @@ void main() {
     final DrawableRoot root = await parser.parse(svgStr);
 
     expect(root.id!.isEmpty, true);
-    expect(find<DrawableGroup>(root, 'Page-1') != null, true);
-    expect(find<DrawableGroup>(root, 'iPhone-8') != null, true);
-    expect(find<DrawableGroup>(root, 'stick_figure') != null, true);
-    expect(find<DrawableShape>(root, 'Oval') != null, true);
+    expect(find<DrawableGroup>(root, 'Page-1'), isNotNull);
+    expect(find<DrawableGroup>(root, 'iPhone-8'), isNotNull);
+    expect(find<DrawableGroup>(root, 'stick_figure'), isNotNull);
+    expect(find<DrawableShape>(root, 'Oval'), isNotNull);
   });
 
   test('Throws with unsupported elements with warnings as errors enabled', () async {
@@ -363,7 +363,7 @@ void main() {
     final SvgParser parser = SvgParser();
     final DrawableRoot root = await parser.parse(svgStr);
 
-    expect(find<DrawableText>(root, 'preserve-space') != null, true);
+    expect(find<DrawableText>(root, 'preserve-space'), isNotNull);
     // Empty text elements get removed
     expect(find<DrawableText>(root, 'remove-space') != null, false);
   });
@@ -1202,11 +1202,135 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
       final DrawableRoot root = await SvgParser().parse(svgStr);
       final DrawableGroup? circle = find<DrawableGroup>(root, 'anotherCircle');
       expect(circle, isNotNull);
+      final DrawableShape shape = circle!.children!.first as DrawableShape;
+      expect(shape.style.stroke?.color, const Color(0xff0000ff));
+      expect(circle.style?.fill?.color, const Color(0xff0000ff));
     });
 
-    // TODO(ikbendewilliam): More tests!
+    test('ref behind use inside group', () async {
+      const String svgStr = '''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <g id="group">
+    <use id="anotherCircle" href="#circle" x="2em" y="4em" fill="blue"/>
+    <circle id="circle" cx="5" cy="5" r="4" stroke="blue"/>
+  </g>
+</svg>
+''';
+      final DrawableRoot root = await SvgParser().parse(svgStr);
+      final DrawableGroup? group = find<DrawableGroup>(root, 'group');
+      expect(group, isNotNull);
+      final DrawableGroup? circle = find<DrawableGroup>(group!, 'anotherCircle');
+      expect(circle, isNotNull);
+    });
 
-    test('defs behind paths that uses it', () async {
+    test('multiple use for same ref', () async {
+      const String svgStr = '''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <use id="circle1" href="#circle" x="2em" y="4em" fill="blue"/>
+  <use id="circle2" href="#circle" x="2em" y="4em" fill="blue"/>
+  <use id="circle3" href="#circle" x="2em" y="4em" fill="blue"/>
+  <circle id="circle" cx="5" cy="5" r="4" stroke="blue"/>
+</svg>
+''';
+      final DrawableRoot root = await SvgParser().parse(svgStr);
+      expect(find<DrawableGroup>(root, 'circle1'), isNotNull);
+      expect(find<DrawableGroup>(root, 'circle2'), isNotNull);
+      expect(find<DrawableGroup>(root, 'circle3'), isNotNull);
+    });
+
+    test('multiple refs behind use inside groups', () async {
+      const String svgStr = '''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <g id="group1">
+    <use id="circle3" href="#circle1" x="2em" y="4em" fill="blue"/>
+    <use id="circle4" href="#circle2" x="2em" y="4em" fill="blue"/>
+    <circle id="circle1" cx="5" cy="5" r="4" stroke="blue"/>
+    <circle id="circle2" cx="5" cy="5" r="4" stroke="blue"/>
+  </g>
+  <g id="group2">
+    <use id="circle7" href="#circle5" x="2em" y="4em" fill="blue"/>
+    <use id="circle8" href="#circle6" x="2em" y="4em" fill="blue"/>
+    <circle id="circle5" cx="5" cy="5" r="4" stroke="blue"/>
+    <circle id="circle6" cx="5" cy="5" r="4" stroke="blue"/>
+  </g>
+</svg>
+''';
+      final DrawableRoot root = await SvgParser().parse(svgStr);
+      final DrawableGroup? group1 = find<DrawableGroup>(root, 'group1');
+      final DrawableGroup? group2 = find<DrawableGroup>(root, 'group2');
+      expect(group1, isNotNull);
+      expect(group2, isNotNull);
+      expect(find<DrawableGroup>(group1!, 'circle3'), isNotNull);
+      expect(find<DrawableGroup>(group1, 'circle4'), isNotNull);
+      expect(find<DrawableGroup>(group2!, 'circle7'), isNotNull);
+      expect(find<DrawableGroup>(group2, 'circle8'), isNotNull);
+    });
+
+    test('defs in front of paths that use it', () async {
+      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    <defs>
+      <linearGradient id="triangleGradient">
+          <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
+          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+      </linearGradient>
+      <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+          <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
+          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+      </linearGradient>
+    </defs>
+    <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
+    <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
+    <path id="path3" fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
+    <g id="group1" transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+        <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+        <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+    </g>
+    <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
+</svg>''';
+      final SvgParser parser = SvgParser();
+      final DrawableRoot root = await parser.parse(svgStr);
+
+      expect(root.id == 'svgRoot', true);
+      expect(find<DrawableGroup>(root, 'group1'), isNotNull);
+      expect(find<DrawableShape>(root, 'path1'), isNotNull);
+      expect(find<DrawableShape>(root, 'path2'), isNotNull);
+      expect(find<DrawableShape>(root, 'path3'), isNotNull);
+      expect(find<DrawableShape>(root, 'path4'), isNotNull);
+    });
+
+    test('defs inbetween paths that use it', () async {
+      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
+    <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
+    <path id="path3" fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
+    <defs>
+      <linearGradient id="triangleGradient">
+          <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
+          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+      </linearGradient>
+      <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+          <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
+          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+      </linearGradient>
+    </defs>
+    <g id="group1" transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+        <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+        <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+    </g>
+    <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
+</svg>''';
+      final SvgParser parser = SvgParser();
+      final DrawableRoot root = await parser.parse(svgStr);
+
+      expect(root.id == 'svgRoot', true);
+      expect(find<DrawableGroup>(root, 'group1'), isNotNull);
+      expect(find<DrawableShape>(root, 'path1'), isNotNull);
+      expect(find<DrawableShape>(root, 'path2'), isNotNull);
+      expect(find<DrawableShape>(root, 'path3'), isNotNull);
+      expect(find<DrawableShape>(root, 'path4'), isNotNull);
+    });
+
+    test('defs behind paths that use it', () async {
       const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
     <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
@@ -1231,11 +1355,72 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
       final DrawableRoot root = await parser.parse(svgStr);
 
       expect(root.id == 'svgRoot', true);
-      expect(find<DrawableGroup>(root, 'group1') != null, true);
-      expect(find<DrawableShape>(root, 'path1') != null, true);
-      expect(find<DrawableShape>(root, 'path2') != null, true);
-      expect(find<DrawableShape>(root, 'path3') != null, true);
-      expect(find<DrawableShape>(root, 'path4') != null, true);
+      expect(find<DrawableGroup>(root, 'group1'), isNotNull);
+      expect(find<DrawableShape>(root, 'path1'), isNotNull);
+      expect(find<DrawableShape>(root, 'path2'), isNotNull);
+      expect(find<DrawableShape>(root, 'path3'), isNotNull);
+      expect(find<DrawableShape>(root, 'path4'), isNotNull);
+    });
+
+    test('group with defs behind paths that use it', () async {
+      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+  <g id="group1">
+    <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
+    <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
+    <path id="path3" fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
+    <g id="group2" transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+        <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+        <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+    </g>
+    <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
+    <defs>
+        <linearGradient id="triangleGradient">
+            <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
+            <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+        </linearGradient>
+        <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+            <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
+            <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+        </linearGradient>
+    </defs>
+  </g>
+</svg>''';
+      final SvgParser parser = SvgParser();
+      final DrawableRoot root = await parser.parse(svgStr);
+
+      expect(root.id == 'svgRoot', true);
+      final DrawableGroup? group1 = find<DrawableGroup>(root, 'group1');
+      expect(group1, isNotNull);
+      expect(find<DrawableGroup>(group1!, 'group2'), isNotNull);
+      expect(find<DrawableShape>(group1, 'path1'), isNotNull);
+      expect(find<DrawableShape>(group1, 'path2'), isNotNull);
+      expect(find<DrawableShape>(group1, 'path3'), isNotNull);
+      expect(find<DrawableShape>(group1, 'path4'), isNotNull);
+    });
+
+    test('defs behind refs behind use and chained (use depends on circle, which depends on linearGradient in defs)', () async {
+      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+  <g id="group1" transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+    <use id="anotherCircle" href="#circle" x="2em" y="4em" fill="blue"/>
+    <circle id="circle" cx="5" cy="5" r="4" stroke="url(#rectangleGradient)"/>
+  </g>
+  <defs>
+      <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+          <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
+          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+      </linearGradient>
+  </defs>
+</svg>''';
+      final SvgParser parser = SvgParser();
+      final DrawableRoot root = await parser.parse(svgStr);
+
+      final DrawableGroup? group1 = find<DrawableGroup>(root, 'group1');
+      expect(group1, isNotNull);
+      final DrawableGroup? circle = find<DrawableGroup>(group1!, 'anotherCircle');
+      expect(circle, isNotNull);
+      final DrawableShape shape = circle!.children!.first as DrawableShape;
+      expect(shape.style.stroke?.color, const Color(0xff0000ff));
+      expect(circle.style?.fill?.color, const Color(0xff0000ff));
     });
   });
 }

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -1180,6 +1180,18 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
   });
 
   group('out of order ref and defs', () {
+    test('ref before use', () async {
+      const String svgStr = '''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle id="circle" cx="5" cy="5" r="4" stroke="blue"/>
+  <use id="anotherCircle" href="#circle" x="2em" y="4em" fill="blue"/>
+</svg>
+''';
+      final DrawableRoot root = await SvgParser().parse(svgStr);
+      final DrawableGroup? circle = find<DrawableGroup>(root, 'anotherCircle');
+      expect(circle, isNotNull);
+    });
+
     test('ref behind use', () async {
       const String svgStr = '''
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -15,11 +15,16 @@ void main() {
     expected.translate(0.338957, 0.010104, 0);
     expected.translate(-0.5214, 0.125, 0);
     expected.translate(0.987, 0.789, 0);
-    expect(parseTransform('translate(0.338957,0.010104), translate(-0.5214,0.125),translate(0.987,0.789)'), expected);
+    expect(
+        parseTransform(
+            'translate(0.338957,0.010104), translate(-0.5214,0.125),translate(0.987,0.789)'),
+        expected);
 
     expected = Matrix4.translationValues(0.338957, 0.010104, 0);
     expected.scale(0.869768, 1.000000, 1.0);
-    expect(parseTransform('translate(0.338957,0.010104),scale(0.869768,1.000000)'), expected);
+    expect(
+        parseTransform('translate(0.338957,0.010104),scale(0.869768,1.000000)'),
+        expected);
   });
 
   test('SVG Transform parser tests', () {
@@ -28,11 +33,14 @@ void main() {
 
     expect(parseTransform('skewX(60)'), Matrix4.skewX(60.0));
     expect(parseTransform('skewY(60)'), Matrix4.skewY(60.0));
-    expect(parseTransform('translate(10,0.0)'), Matrix4.translationValues(10.0, 0.0, 0.0));
+    expect(parseTransform('translate(10,0.0)'),
+        Matrix4.translationValues(10.0, 0.0, 0.0));
     expect(parseTransform('skewX(60)'), Matrix4.skewX(60.0));
 
-    expect(parseTransform('scale(10)'), Matrix4.identity()..scale(10.0, 10.0, 1.0));
-    expect(parseTransform('scale(10, 15)'), Matrix4.identity()..scale(10.0, 15.0, 1.0));
+    expect(parseTransform('scale(10)'),
+        Matrix4.identity()..scale(10.0, 10.0, 1.0));
+    expect(parseTransform('scale(10, 15)'),
+        Matrix4.identity()..scale(10.0, 15.0, 1.0));
 
     expect(parseTransform('rotate(20)'), Matrix4.rotationZ(radians(20.0)));
     expect(
@@ -66,7 +74,8 @@ void main() {
           5.0, 6.0, 0.0, 1.0
         ]));
 
-    expect(parseTransform('rotate(20)\n\tscale(10)'), Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
+    expect(parseTransform('rotate(20)\n\tscale(10)'),
+        Matrix4.rotationZ(radians(20.0))..scale(10.0, 10.0, 1.0));
   });
 
   test('FillRule tests', () {
@@ -187,7 +196,8 @@ void main() {
       ),
     );
 
-    expect(() => parserState.parseFontSize('invalid'), throwsA(const TypeMatcher<StateError>()));
+    expect(() => parserState.parseFontSize('invalid'),
+        throwsA(const TypeMatcher<StateError>()));
   });
 
   test('relative font size tests', () {
@@ -240,7 +250,8 @@ void main() {
   });
 
   test('Check any ids', () async {
-    const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    const String svgStr =
+        '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <defs>
         <linearGradient id="triangleGradient">
             <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
@@ -301,7 +312,8 @@ void main() {
     expect(find<DrawableShape>(root, 'Oval'), isNotNull);
   });
 
-  test('Throws with unsupported elements with warnings as errors enabled', () async {
+  test('Throws with unsupported elements with warnings as errors enabled',
+      () async {
     const String svgStr = '''<?xml version="1.0" encoding="UTF-8"?>
 <svg width="27px" height="90px" viewBox="5 10 18 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
@@ -577,7 +589,8 @@ void main() {
           ),
         );
 
-        final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient-1)');
+        final DrawableLinearGradient? gradient =
+            root.definitions.getGradient('url(#gradient-1)');
 
         expect(gradient, isNotNull);
 
@@ -617,7 +630,8 @@ void main() {
           ),
         );
 
-        final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient-1)');
+        final DrawableLinearGradient? gradient =
+            root.definitions.getGradient('url(#gradient-1)');
 
         expect(gradient, isNotNull);
 
@@ -657,7 +671,8 @@ void main() {
           ),
         );
 
-        final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient-1)');
+        final DrawableLinearGradient? gradient =
+            root.definitions.getGradient('url(#gradient-1)');
 
         expect(gradient, isNotNull);
 
@@ -769,7 +784,8 @@ void main() {
         ),
       );
 
-      final DrawableRadialGradient? gradient = root.definitions.getGradient('url(#gradient)');
+      final DrawableRadialGradient? gradient =
+          root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -803,7 +819,8 @@ void main() {
         ),
       );
 
-      final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient)');
+      final DrawableLinearGradient? gradient =
+          root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -833,7 +850,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1em" y="0.5em" width="2em" height="1.5em" /
         ),
       );
 
-      final DrawableRasterImage? image = find<DrawableRasterImage>(root, 'image');
+      final DrawableRasterImage? image =
+          find<DrawableRasterImage>(root, 'image');
 
       const Offset expectedOffset = Offset(fontSize * 1, fontSize * 0.5);
       const Size expectedSize = Size(fontSize * 2, fontSize * 1.5);
@@ -947,7 +965,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1em" y="0.5em" width="2em" height="1.5em" /
         ),
       );
 
-      final DrawableRadialGradient? gradient = root.definitions.getGradient('url(#gradient)');
+      final DrawableRadialGradient? gradient =
+          root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -983,7 +1002,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1em" y="0.5em" width="2em" height="1.5em" /
         ),
       );
 
-      final DrawableLinearGradient? gradient = root.definitions.getGradient('url(#gradient)');
+      final DrawableLinearGradient? gradient =
+          root.definitions.getGradient('url(#gradient)');
 
       expect(gradient, isNotNull);
 
@@ -1015,7 +1035,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
         ),
       );
 
-      final DrawableRasterImage? image = find<DrawableRasterImage>(root, 'image');
+      final DrawableRasterImage? image =
+          find<DrawableRasterImage>(root, 'image');
 
       const Offset expectedOffset = Offset(xHeight * 1, xHeight * 0.5);
       const Size expectedSize = Size(xHeight * 2, xHeight * 1.5);
@@ -1174,7 +1195,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
     final DrawableRoot root = await parser.parse(svgStr);
 
     expect(root.children.length, 1);
-    final DrawableRasterImage image = root.children.first as DrawableRasterImage;
+    final DrawableRasterImage image =
+        root.children.first as DrawableRasterImage;
     expect(image.size!.width, image.image.width);
     expect(image.size!.height, image.image.height);
   });
@@ -1219,7 +1241,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
       final DrawableRoot root = await SvgParser().parse(svgStr);
       final DrawableGroup? group = find<DrawableGroup>(root, 'group');
       expect(group, isNotNull);
-      final DrawableGroup? circle = find<DrawableGroup>(group!, 'anotherCircle');
+      final DrawableGroup? circle =
+          find<DrawableGroup>(group!, 'anotherCircle');
       expect(circle, isNotNull);
     });
 
@@ -1267,7 +1290,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
     });
 
     test('defs in front of paths that use it', () async {
-      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+      const String svgStr =
+          '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <defs>
       <linearGradient id="triangleGradient">
           <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
@@ -1299,7 +1323,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
     });
 
     test('defs inbetween paths that use it', () async {
-      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+      const String svgStr =
+          '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
     <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
     <path id="path3" fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
@@ -1331,7 +1356,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
     });
 
     test('defs behind paths that use it', () async {
-      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+      const String svgStr =
+          '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
     <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
     <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
     <path id="path3" fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
@@ -1363,7 +1389,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
     });
 
     test('group with defs behind paths that use it', () async {
-      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+      const String svgStr =
+          '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
   <g id="group1">
     <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
     <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
@@ -1398,8 +1425,11 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
       expect(find<DrawableShape>(group1, 'path4'), isNotNull);
     });
 
-    test('defs behind refs behind use and chained (use depends on circle, which depends on linearGradient in defs)', () async {
-      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    test(
+        'defs behind refs behind use and chained (use depends on circle, which depends on linearGradient in defs)',
+        () async {
+      const String svgStr =
+          '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
   <g id="group1" transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
     <use id="anotherCircle" href="#circle" x="2em" y="4em" fill="blue"/>
     <circle id="circle" cx="5" cy="5" r="4" stroke="url(#rectangleGradient)"/>
@@ -1416,7 +1446,8 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
 
       final DrawableGroup? group1 = find<DrawableGroup>(root, 'group1');
       expect(group1, isNotNull);
-      final DrawableGroup? circle = find<DrawableGroup>(group1!, 'anotherCircle');
+      final DrawableGroup? circle =
+          find<DrawableGroup>(group1!, 'anotherCircle');
       expect(circle, isNotNull);
       final DrawableShape shape = circle!.children!.first as DrawableShape;
       expect(shape.style.stroke?.shader is Gradient, true);

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -1,4 +1,4 @@
-import 'dart:ui' show Color, Offset, PathFillType, Size;
+import 'dart:ui' show Color, Offset, PathFillType, Size, Gradient;
 
 import 'package:flutter_svg/parser.dart';
 import 'package:flutter_svg/src/svg/parsers.dart';
@@ -1419,7 +1419,7 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
       final DrawableGroup? circle = find<DrawableGroup>(group1!, 'anotherCircle');
       expect(circle, isNotNull);
       final DrawableShape shape = circle!.children!.first as DrawableShape;
-      expect(shape.style.stroke?.color, const Color(0xff0000ff));
+      expect(shape.style.stroke?.shader is Gradient, true);
       expect(circle.style?.fill?.color, const Color(0xff0000ff));
     });
   });

--- a/test/svg_parsers_test.dart
+++ b/test/svg_parsers_test.dart
@@ -1178,4 +1178,52 @@ BAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" x="1ex" y="0.5ex" width="2ex" height="1.5ex" /
     expect(image.size!.width, image.image.width);
     expect(image.size!.height, image.image.height);
   });
+
+  group('out of order ref and defs', () {
+    test('ref behind use', () async {
+      const String svgStr = '''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <use id="anotherCircle" href="#circle" x="2em" y="4em" fill="blue"/>
+  <circle id="circle" cx="5" cy="5" r="4" stroke="blue"/>
+</svg>
+''';
+      final DrawableRoot root = await SvgParser().parse(svgStr);
+      final DrawableGroup? circle = find<DrawableGroup>(root, 'anotherCircle');
+      expect(circle, isNotNull);
+    });
+
+    // TODO(ikbendewilliam): More tests!
+
+    test('defs behind paths that uses it', () async {
+      const String svgStr = '''<svg id="svgRoot" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+    <path id="path1" fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
+    <path id="path2" fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
+    <path id="path3" fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
+    <g id="group1" transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+        <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+        <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+    </g>
+    <path id="path4" d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
+    <defs>
+        <linearGradient id="triangleGradient">
+            <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
+            <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+        </linearGradient>
+        <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+            <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
+            <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+        </linearGradient>
+    </defs>
+</svg>''';
+      final SvgParser parser = SvgParser();
+      final DrawableRoot root = await parser.parse(svgStr);
+
+      expect(root.id == 'svgRoot', true);
+      expect(find<DrawableGroup>(root, 'group1') != null, true);
+      expect(find<DrawableShape>(root, 'path1') != null, true);
+      expect(find<DrawableShape>(root, 'path2') != null, true);
+      expect(find<DrawableShape>(root, 'path3') != null, true);
+      expect(find<DrawableShape>(root, 'path4') != null, true);
+    });
+  });
 }

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -1118,6 +1118,14 @@ const String simpleSvg = '''
 
 const String svgStr = '''
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 166 202">
+  <path fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
+  <path fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
+  <path fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
+  <g transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
+      <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+      <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+  </g>
+  <path d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
   <defs>
       <linearGradient id="triangleGradient">
           <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
@@ -1128,14 +1136,6 @@ const String svgStr = '''
           <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
       </linearGradient>
   </defs>
-  <path fill="#42A5F5" fill-opacity=".8" d="M37.7 128.9 9.8 101 100.4 10.4 156.2 10.4"/>
-  <path fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
-  <path fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
-  <g transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
-      <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
-      <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
-  </g>
-  <path d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
 </svg>
 ''';
 

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -23,7 +23,8 @@ class _TolerantComparator extends LocalFileComparator {
       if (result.diffPercent >= .06) {
         throw FlutterError(error);
       } else {
-        print('Warning - golden differed less than .06% (${result.diffPercent}%), '
+        print(
+            'Warning - golden differed less than .06% (${result.diffPercent}%), '
             'ignoring failure but producing output');
         print(error);
       }
@@ -44,8 +45,10 @@ void main() {
   late FakeHttpClient fakeHttpClient;
 
   setUpAll(() {
-    final LocalFileComparator oldComparator = goldenFileComparator as LocalFileComparator;
-    final _TolerantComparator newComparator = _TolerantComparator(Uri.parse(oldComparator.basedir.toString() + 'test'));
+    final LocalFileComparator oldComparator =
+        goldenFileComparator as LocalFileComparator;
+    final _TolerantComparator newComparator = _TolerantComparator(
+        Uri.parse(oldComparator.basedir.toString() + 'test'));
     expect(oldComparator.basedir, newComparator.basedir);
     goldenFileComparator = newComparator;
   });
@@ -58,7 +61,9 @@ void main() {
     fakeHttpClient = FakeHttpClient(fakeRequest);
   });
 
-  testWidgets('SvgPicture does not use a color filtering widget when no color specified', (WidgetTester tester) async {
+  testWidgets(
+      'SvgPicture does not use a color filtering widget when no color specified',
+      (WidgetTester tester) async {
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
       SvgPicture.string(
@@ -72,7 +77,8 @@ void main() {
     expect(find.byType(ColorFiltered), findsNothing);
   });
 
-  testWidgets('SvgPicture does not invalidate the cache when color changes', (WidgetTester tester) async {
+  testWidgets('SvgPicture does not invalidate the cache when color changes',
+      (WidgetTester tester) async {
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
       SvgPicture.string(
@@ -97,7 +103,9 @@ void main() {
     expect(PictureProvider.cache.count, 1);
   });
 
-  testWidgets('SvgPicture does invalidate the cache when color changes and color filter is cached', (WidgetTester tester) async {
+  testWidgets(
+      'SvgPicture does invalidate the cache when color changes and color filter is cached',
+      (WidgetTester tester) async {
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
       SvgPicture.string(
@@ -124,7 +132,9 @@ void main() {
     expect(PictureProvider.cache.count, 2);
   });
 
-  testWidgets('SvgPicture does invalidate the cache when color changes and color filter is cached (override)', (WidgetTester tester) async {
+  testWidgets(
+      'SvgPicture does invalidate the cache when color changes and color filter is cached (override)',
+      (WidgetTester tester) async {
     svg.cacheColorFilterOverride = true;
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
@@ -150,7 +160,8 @@ void main() {
     expect(PictureProvider.cache.count, 2);
   });
 
-  testWidgets('SvgPicture can work with a FittedBox', (WidgetTester tester) async {
+  testWidgets('SvgPicture can work with a FittedBox',
+      (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       MediaQuery(
@@ -353,7 +364,8 @@ void main() {
     await _checkWidgetAndGolden(key, 'flutter_logo.asset.png');
   });
 
-  testWidgets('SvgPicture.asset DefaultAssetBundle', (WidgetTester tester) async {
+  testWidgets('SvgPicture.asset DefaultAssetBundle',
+      (WidgetTester tester) async {
     final FakeAssetBundle fakeAsset = FakeAssetBundle();
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
@@ -405,7 +417,8 @@ void main() {
           data: MediaQueryData.fromWindow(window),
           child: RepaintBoundary(
             key: key,
-            child: SvgPicture.network('test.svg', headers: const <String, String>{'a': 'b'}),
+            child: SvgPicture.network('test.svg',
+                headers: const <String, String>{'a': 'b'}),
           ),
         ),
       );
@@ -414,7 +427,8 @@ void main() {
     }, createHttpClient: (SecurityContext? c) => fakeHttpClient);
   });
 
-  testWidgets('SvgPicture can be created without a MediaQuery', (WidgetTester tester) async {
+  testWidgets('SvgPicture can be created without a MediaQuery',
+      (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       RepaintBoundary(
@@ -507,7 +521,8 @@ void main() {
     expect(find.byType(Semantics), findsNothing);
   }, semanticsEnabled: true);
 
-  testWidgets('SvgPicture colorFilter - flutter logo', (WidgetTester tester) async {
+  testWidgets('SvgPicture colorFilter - flutter logo',
+      (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       RepaintBoundary(
@@ -525,7 +540,8 @@ void main() {
     await _checkWidgetAndGolden(key, 'flutter_logo.string.color_filter.png');
   });
 
-  testWidgets('SvgPicture colorFilter - flutter logo - BlendMode.color', (WidgetTester tester) async {
+  testWidgets('SvgPicture colorFilter - flutter logo - BlendMode.color',
+      (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       RepaintBoundary(
@@ -541,11 +557,13 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    await _checkWidgetAndGolden(key, 'flutter_logo.string.color_filter.blendmode_color.png');
+    await _checkWidgetAndGolden(
+        key, 'flutter_logo.string.color_filter.blendmode_color.png');
   });
 
   testWidgets('SvgPicture colorFilter with text', (WidgetTester tester) async {
-    const String svgData = '''<svg font-family="arial" font-size="14" height="160" width="88" xmlns="http://www.w3.org/2000/svg">
+    const String svgData =
+        '''<svg font-family="arial" font-size="14" height="160" width="88" xmlns="http://www.w3.org/2000/svg">
   <g stroke="#000" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="1" stroke-linejoin="miter">
     <g>
       <line x1="60" x2="88" y1="136" y2="136"/>
@@ -586,7 +604,8 @@ void main() {
     expect(find.byType(SvgPicture), findsOneWidget);
   });
 
-  testWidgets('SvgPicture.string respects clipBehavior', (WidgetTester tester) async {
+  testWidgets('SvgPicture.string respects clipBehavior',
+      (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: SvgPicture.string(svgStr),
@@ -594,7 +613,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject =
+        tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -609,7 +629,8 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('SvgPicture.asset respects clipBehavior', (WidgetTester tester) async {
+  testWidgets('SvgPicture.asset respects clipBehavior',
+      (WidgetTester tester) async {
     final FakeAssetBundle fakeAsset = FakeAssetBundle();
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -621,7 +642,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject =
+        tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -640,7 +662,8 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('SvgPicture.memory respects clipBehavior', (WidgetTester tester) async {
+  testWidgets('SvgPicture.memory respects clipBehavior',
+      (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: SvgPicture.memory(svgBytes),
@@ -648,7 +671,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject =
+        tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -663,7 +687,8 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('SvgPicture.network respects clipBehavior', (WidgetTester tester) async {
+  testWidgets('SvgPicture.network respects clipBehavior',
+      (WidgetTester tester) async {
     await HttpOverrides.runZoned(() async {
       await tester.pumpWidget(
         Directionality(
@@ -674,7 +699,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // Check that the render object has received the default clip behavior.
-      final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
+      final RenderFittedBox renderObject =
+          tester.allRenderObjects.whereType<RenderFittedBox>().first;
       expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
       // Pump a new widget to check that the render object can update its clip
@@ -698,7 +724,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject =
+        tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -737,7 +764,8 @@ void main() {
       await _checkWidgetAndGolden(key, 'circle.em_ex.png');
     });
 
-    testWidgets('rect (x, y, width, height, rx, ry)', (WidgetTester tester) async {
+    testWidgets('rect (x, y, width, height, rx, ry)',
+        (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
 
       const String svgStr = '''
@@ -835,7 +863,8 @@ void main() {
       await _checkWidgetAndGolden(key, 'circle.em_ex.png');
     });
 
-    testWidgets('rect (x, y, width, height, rx, ry)', (WidgetTester tester) async {
+    testWidgets('rect (x, y, width, height, rx, ry)',
+        (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
 
       const String svgStr = '''
@@ -936,7 +965,9 @@ void main() {
     );
   });
 
-  testWidgets('Update widget without a cache does not result in an disposed picture', (WidgetTester tester) async {
+  testWidgets(
+      'Update widget without a cache does not result in an disposed picture',
+      (WidgetTester tester) async {
     final int oldCacheSize = PictureProvider.cache.maximumSize;
     PictureProvider.cache.maximumSize = 0;
     final GlobalKey key = GlobalKey();
@@ -1092,7 +1123,8 @@ class FakeHttpClientResponse extends Fake implements HttpClientResponse {
   int contentLength = svgStr.length;
 
   @override
-  HttpClientResponseCompressionState get compressionState => HttpClientResponseCompressionState.notCompressed;
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
 
   @override
   StreamSubscription<List<int>> listen(

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -1122,19 +1122,19 @@ const String svgStr = '''
   <path fill="#42A5F5" fill-opacity=".8" d="M156.2 94 100.4 94 79.5 114.9 107.4 142.8"/>
   <path fill="#0D47A1" d="M79.5 170.7 100.4 191.6 156.2 191.6 156.2 191.6 107.4 142.8"/>
   <g transform="matrix(0.7071, -0.7071, 0.7071, 0.7071, -77.667, 98.057)">
-      <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
-      <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
+    <rect width="39.4" height="39.4" x="59.8" y="123.1" fill="#42A5F5" />
+    <rect width="39.4" height="5.5" x="59.8" y="162.5" fill="url(#rectangleGradient)" />
   </g>
   <path d="M79.5 170.7 120.9 156.4 107.4 142.8" fill="url(#triangleGradient)" />
   <defs>
-      <linearGradient id="triangleGradient">
-          <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
-          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
-      </linearGradient>
-      <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
-          <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
-          <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
-      </linearGradient>
+    <linearGradient id="triangleGradient">
+      <stop offset="20%" stop-color="#000000" stop-opacity=".55" />
+      <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+    </linearGradient>
+    <linearGradient id="rectangleGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="20%" stop-color="#000000" stop-opacity=".15" />
+      <stop offset="85%" stop-color="#616161" stop-opacity=".01" />
+    </linearGradient>
   </defs>
 </svg>
 ''';

--- a/test/widget_svg_test.dart
+++ b/test/widget_svg_test.dart
@@ -7,7 +7,6 @@ import 'dart:ui' show window;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:flutter_test/flutter_test.dart';
 
 class _TolerantComparator extends LocalFileComparator {
@@ -24,8 +23,7 @@ class _TolerantComparator extends LocalFileComparator {
       if (result.diffPercent >= .06) {
         throw FlutterError(error);
       } else {
-        print(
-            'Warning - golden differed less than .06% (${result.diffPercent}%), '
+        print('Warning - golden differed less than .06% (${result.diffPercent}%), '
             'ignoring failure but producing output');
         print(error);
       }
@@ -46,10 +44,8 @@ void main() {
   late FakeHttpClient fakeHttpClient;
 
   setUpAll(() {
-    final LocalFileComparator oldComparator =
-        goldenFileComparator as LocalFileComparator;
-    final _TolerantComparator newComparator = _TolerantComparator(
-        Uri.parse(oldComparator.basedir.toString() + 'test'));
+    final LocalFileComparator oldComparator = goldenFileComparator as LocalFileComparator;
+    final _TolerantComparator newComparator = _TolerantComparator(Uri.parse(oldComparator.basedir.toString() + 'test'));
     expect(oldComparator.basedir, newComparator.basedir);
     goldenFileComparator = newComparator;
   });
@@ -62,9 +58,7 @@ void main() {
     fakeHttpClient = FakeHttpClient(fakeRequest);
   });
 
-  testWidgets(
-      'SvgPicture does not use a color filtering widget when no color specified',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture does not use a color filtering widget when no color specified', (WidgetTester tester) async {
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
       SvgPicture.string(
@@ -78,8 +72,7 @@ void main() {
     expect(find.byType(ColorFiltered), findsNothing);
   });
 
-  testWidgets('SvgPicture does not invalidate the cache when color changes',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture does not invalidate the cache when color changes', (WidgetTester tester) async {
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
       SvgPicture.string(
@@ -104,9 +97,7 @@ void main() {
     expect(PictureProvider.cache.count, 1);
   });
 
-  testWidgets(
-      'SvgPicture does invalidate the cache when color changes and color filter is cached',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture does invalidate the cache when color changes and color filter is cached', (WidgetTester tester) async {
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
       SvgPicture.string(
@@ -133,9 +124,7 @@ void main() {
     expect(PictureProvider.cache.count, 2);
   });
 
-  testWidgets(
-      'SvgPicture does invalidate the cache when color changes and color filter is cached (override)',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture does invalidate the cache when color changes and color filter is cached (override)', (WidgetTester tester) async {
     svg.cacheColorFilterOverride = true;
     expect(PictureProvider.cache.count, 0);
     await tester.pumpWidget(
@@ -161,8 +150,7 @@ void main() {
     expect(PictureProvider.cache.count, 2);
   });
 
-  testWidgets('SvgPicture can work with a FittedBox',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture can work with a FittedBox', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       MediaQuery(
@@ -365,8 +353,7 @@ void main() {
     await _checkWidgetAndGolden(key, 'flutter_logo.asset.png');
   });
 
-  testWidgets('SvgPicture.asset DefaultAssetBundle',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture.asset DefaultAssetBundle', (WidgetTester tester) async {
     final FakeAssetBundle fakeAsset = FakeAssetBundle();
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
@@ -418,8 +405,7 @@ void main() {
           data: MediaQueryData.fromWindow(window),
           child: RepaintBoundary(
             key: key,
-            child: SvgPicture.network('test.svg',
-                headers: const <String, String>{'a': 'b'}),
+            child: SvgPicture.network('test.svg', headers: const <String, String>{'a': 'b'}),
           ),
         ),
       );
@@ -428,8 +414,7 @@ void main() {
     }, createHttpClient: (SecurityContext? c) => fakeHttpClient);
   });
 
-  testWidgets('SvgPicture can be created without a MediaQuery',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture can be created without a MediaQuery', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       RepaintBoundary(
@@ -522,8 +507,7 @@ void main() {
     expect(find.byType(Semantics), findsNothing);
   }, semanticsEnabled: true);
 
-  testWidgets('SvgPicture colorFilter - flutter logo',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture colorFilter - flutter logo', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       RepaintBoundary(
@@ -541,8 +525,7 @@ void main() {
     await _checkWidgetAndGolden(key, 'flutter_logo.string.color_filter.png');
   });
 
-  testWidgets('SvgPicture colorFilter - flutter logo - BlendMode.color',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture colorFilter - flutter logo - BlendMode.color', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
       RepaintBoundary(
@@ -558,13 +541,11 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    await _checkWidgetAndGolden(
-        key, 'flutter_logo.string.color_filter.blendmode_color.png');
+    await _checkWidgetAndGolden(key, 'flutter_logo.string.color_filter.blendmode_color.png');
   });
 
   testWidgets('SvgPicture colorFilter with text', (WidgetTester tester) async {
-    const String svgData =
-        '''<svg font-family="arial" font-size="14" height="160" width="88" xmlns="http://www.w3.org/2000/svg">
+    const String svgData = '''<svg font-family="arial" font-size="14" height="160" width="88" xmlns="http://www.w3.org/2000/svg">
   <g stroke="#000" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="1" stroke-linejoin="miter">
     <g>
       <line x1="60" x2="88" y1="136" y2="136"/>
@@ -594,15 +575,6 @@ void main() {
     await _checkWidgetAndGolden(key, 'text_color_filter.png');
   });
 
-  testWidgets('Nested SVG elements report a FlutterError',
-      (WidgetTester tester) async {
-    await svg.fromSvgString(
-        '<svg viewBox="0 0 166 202"><svg viewBox="0 0 166 202"></svg></svg>',
-        'test');
-    final UnsupportedError error = tester.takeException() as UnsupportedError;
-    expect(error.message, 'Unsupported nested <svg> element.');
-  });
-
   testWidgets('Can take AlignmentDirectional', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -614,8 +586,7 @@ void main() {
     expect(find.byType(SvgPicture), findsOneWidget);
   });
 
-  testWidgets('SvgPicture.string respects clipBehavior',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture.string respects clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: SvgPicture.string(svgStr),
@@ -623,8 +594,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject =
-        tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -639,8 +609,7 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('SvgPicture.asset respects clipBehavior',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture.asset respects clipBehavior', (WidgetTester tester) async {
     final FakeAssetBundle fakeAsset = FakeAssetBundle();
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -652,8 +621,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject =
-        tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -672,8 +640,7 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('SvgPicture.memory respects clipBehavior',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture.memory respects clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: SvgPicture.memory(svgBytes),
@@ -681,8 +648,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject =
-        tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -697,8 +663,7 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('SvgPicture.network respects clipBehavior',
-      (WidgetTester tester) async {
+  testWidgets('SvgPicture.network respects clipBehavior', (WidgetTester tester) async {
     await HttpOverrides.runZoned(() async {
       await tester.pumpWidget(
         Directionality(
@@ -709,8 +674,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Check that the render object has received the default clip behavior.
-      final RenderFittedBox renderObject =
-          tester.allRenderObjects.whereType<RenderFittedBox>().first;
+      final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
       expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
       // Pump a new widget to check that the render object can update its clip
@@ -734,8 +698,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that the render object has received the default clip behavior.
-    final RenderFittedBox renderObject =
-        tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Pump a new widget to check that the render object can update its clip
@@ -774,8 +737,7 @@ void main() {
       await _checkWidgetAndGolden(key, 'circle.em_ex.png');
     });
 
-    testWidgets('rect (x, y, width, height, rx, ry)',
-        (WidgetTester tester) async {
+    testWidgets('rect (x, y, width, height, rx, ry)', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
 
       const String svgStr = '''
@@ -873,8 +835,7 @@ void main() {
       await _checkWidgetAndGolden(key, 'circle.em_ex.png');
     });
 
-    testWidgets('rect (x, y, width, height, rx, ry)',
-        (WidgetTester tester) async {
+    testWidgets('rect (x, y, width, height, rx, ry)', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
 
       const String svgStr = '''
@@ -975,9 +936,7 @@ void main() {
     );
   });
 
-  testWidgets(
-      'Update widget without a cache does not result in an disposed picture',
-      (WidgetTester tester) async {
+  testWidgets('Update widget without a cache does not result in an disposed picture', (WidgetTester tester) async {
     final int oldCacheSize = PictureProvider.cache.maximumSize;
     PictureProvider.cache.maximumSize = 0;
     final GlobalKey key = GlobalKey();
@@ -1133,8 +1092,7 @@ class FakeHttpClientResponse extends Fake implements HttpClientResponse {
   int contentLength = svgStr.length;
 
   @override
-  HttpClientResponseCompressionState get compressionState =>
-      HttpClientResponseCompressionState.notCompressed;
+  HttpClientResponseCompressionState get compressionState => HttpClientResponseCompressionState.notCompressed;
 
   @override
   StreamSubscription<List<int>> listen(

--- a/test/xml_svg_test.dart
+++ b/test/xml_svg_test.dart
@@ -22,27 +22,20 @@ class TestSvgParserState extends SvgParserState {
 
 void main() {
   test('Xlink href tests', () {
-    final XmlStartElementEvent el =
-        parseEvents('<test href="http://localhost" />').first
-            as XmlStartElementEvent;
+    final XmlStartElementEvent el = parseEvents('<test href="http://localhost" />').first as XmlStartElementEvent;
 
-    final XmlStartElementEvent elXlink =
-        parseEvents('<test xmlns:xlink="$kXlinkNamespace" '
-                'xlink:href="http://localhost" />')
-            .first as XmlStartElementEvent;
+    final XmlStartElementEvent elXlink = parseEvents('<test xmlns:xlink="$kXlinkNamespace" '
+            'xlink:href="http://localhost" />')
+        .first as XmlStartElementEvent;
 
-    expect(
-        getHrefAttribute(el.attributes.toAttributeMap()), 'http://localhost');
-    expect(getHrefAttribute(elXlink.attributes.toAttributeMap()),
-        'http://localhost');
+    expect(getHrefAttribute(el.attributes.toAttributeMap()), 'http://localhost');
+    expect(getHrefAttribute(elXlink.attributes.toAttributeMap()), 'http://localhost');
   });
 
   test('Attribute and style tests', () {
-    final XmlStartElementEvent el =
-        parseEvents('<test stroke="#fff" fill="#eee" stroke-dashpattern="1 2" '
-                'style="stroke-opacity:1;fill-opacity:.23" />')
-            .first as XmlStartElementEvent;
-
+    final XmlStartElementEvent el = parseEvents('<test stroke="#fff" fill="#eee" stroke-dashpattern="1 2" '
+            'style="stroke-opacity:1;fill-opacity:.23" />')
+        .first as XmlStartElementEvent;
     final Map<String, String> attributes = el.attributes.toAttributeMap();
     expect(getAttribute(attributes, 'stroke'), '#fff');
     expect(getAttribute(attributes, 'fill'), '#eee');
@@ -57,46 +50,32 @@ void main() {
 
   // if the parsing logic changes, we can simplify some methods.  for now assert that whitespace in attributes is preserved
   test('Attribute WhiteSpace test', () {
-    final XmlStartElementEvent xd =
-        parseEvents('<test attr="  asdf" attr2="asdf  " attr3="asdf" />').first
-            as XmlStartElementEvent;
+    final XmlStartElementEvent xd = parseEvents('<test attr="  asdf" attr2="asdf  " attr3="asdf" />').first as XmlStartElementEvent;
 
     expect(
       xd.attributes[0].value,
       '  asdf',
-      reason:
-          'XML Parsing implementation no longer preserves leading whitespace in attributes!',
+      reason: 'XML Parsing implementation no longer preserves leading whitespace in attributes!',
     );
     expect(
       xd.attributes[1].value,
       'asdf  ',
-      reason:
-          'XML Parsing implementation no longer preserves trailing whitespace in attributes!',
+      reason: 'XML Parsing implementation no longer preserves trailing whitespace in attributes!',
     );
   });
 
   test('viewBox tests', () {
     const Rect rect = Rect.fromLTWH(0.0, 0.0, 100.0, 100.0);
 
-    final XmlStartElementEvent svgWithViewBox =
-        parseEvents('<svg viewBox="0 0 100 100" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithViewBoxAndWidthHeight =
-        parseEvents('<svg width="50px" height="50px" viewBox="0 0 100 100" />')
-            .first as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithWidthHeight =
-        parseEvents('<svg width="100" height="100" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithViewBoxMinXMinY =
-        parseEvents('<svg viewBox="42 56 100 100" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithNoSizeInfo =
-        parseEvents('<svg />').first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithViewBox = parseEvents('<svg viewBox="0 0 100 100" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithViewBoxAndWidthHeight = parseEvents('<svg width="50px" height="50px" viewBox="0 0 100 100" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithWidthHeight = parseEvents('<svg width="100" height="100" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithViewBoxMinXMinY = parseEvents('<svg viewBox="42 56 100 100" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithNoSizeInfo = parseEvents('<svg />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
 
-    parserState.attributes =
-        svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
+    parserState.attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
     expect(parserState.parseViewBox()!.size, const Size(50, 50));
 
     parserState.attributes = svgWithViewBox.attributes.toAttributeMap();
@@ -105,8 +84,7 @@ void main() {
     parserState.attributes = svgWithViewBox.attributes.toAttributeMap();
     expect(parserState.parseViewBox()!.viewBoxOffset, Offset.zero);
 
-    parserState.attributes =
-        svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
+    parserState.attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
     expect(parserState.parseViewBox()!.viewBoxRect, rect);
 
     parserState.attributes = svgWithWidthHeight.attributes.toAttributeMap();
@@ -129,21 +107,12 @@ void main() {
   });
 
   test('TileMode tests', () {
-    final XmlStartElementEvent pad =
-        parseEvents('<linearGradient spreadMethod="pad" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent reflect =
-        parseEvents('<linearGradient spreadMethod="reflect" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent repeat =
-        parseEvents('<linearGradient spreadMethod="repeat" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent invalid =
-        parseEvents('<linearGradient spreadMethod="invalid" />').first
-            as XmlStartElementEvent;
+    final XmlStartElementEvent pad = parseEvents('<linearGradient spreadMethod="pad" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent reflect = parseEvents('<linearGradient spreadMethod="reflect" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent repeat = parseEvents('<linearGradient spreadMethod="repeat" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent invalid = parseEvents('<linearGradient spreadMethod="invalid" />').first as XmlStartElementEvent;
 
-    final XmlStartElementEvent none =
-        parseEvents('<linearGradient />').first as XmlStartElementEvent;
+    final XmlStartElementEvent none = parseEvents('<linearGradient />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
     parserState.attributes = pad.attributes.toAttributeMap();
@@ -163,12 +132,8 @@ void main() {
   });
 
   test('@stroke-dashoffset tests', () {
-    final XmlStartElementEvent abs =
-        parseEvents('<stroke stroke-dashoffset="20" />').first
-            as XmlStartElementEvent;
-    final XmlStartElementEvent pct =
-        parseEvents('<stroke stroke-dashoffset="20%" />').first
-            as XmlStartElementEvent;
+    final XmlStartElementEvent abs = parseEvents('<stroke stroke-dashoffset="20" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent pct = parseEvents('<stroke stroke-dashoffset="20%" />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
     parserState.attributes = abs.attributes.toAttributeMap();
@@ -199,8 +164,7 @@ void main() {
     expect(parserState.parseFontWeight('normal'), FontWeight.normal);
     expect(parserState.parseFontWeight('bold'), FontWeight.bold);
 
-    expect(
-        () => parserState.parseFontWeight('invalid'), throwsUnsupportedError);
+    expect(() => parserState.parseFontWeight('invalid'), throwsUnsupportedError);
   });
 
   test('font-style tests', () {
@@ -216,46 +180,34 @@ void main() {
   test('text-decoration tests', () {
     final TestSvgParserState parserState = TestSvgParserState();
     expect(parserState.parseTextDecoration('none'), TextDecoration.none);
-    expect(parserState.parseTextDecoration('line-through'),
-        TextDecoration.lineThrough);
-    expect(
-        parserState.parseTextDecoration('overline'), TextDecoration.overline);
-    expect(
-        parserState.parseTextDecoration('underline'), TextDecoration.underline);
+    expect(parserState.parseTextDecoration('line-through'), TextDecoration.lineThrough);
+    expect(parserState.parseTextDecoration('overline'), TextDecoration.overline);
+    expect(parserState.parseTextDecoration('underline'), TextDecoration.underline);
 
     expect(parserState.parseTextDecoration(null), isNull);
-    expect(() => parserState.parseTextDecoration('invalid'),
-        throwsUnsupportedError);
+    expect(() => parserState.parseTextDecoration('invalid'), throwsUnsupportedError);
   });
 
   test('text-decoration-style tests', () {
     final TestSvgParserState parserState = TestSvgParserState();
-    expect(parserState.parseTextDecorationStyle('solid'),
-        TextDecorationStyle.solid);
-    expect(parserState.parseTextDecorationStyle('dashed'),
-        TextDecorationStyle.dashed);
-    expect(parserState.parseTextDecorationStyle('dotted'),
-        TextDecorationStyle.dotted);
-    expect(parserState.parseTextDecorationStyle('double'),
-        TextDecorationStyle.double);
-    expect(
-        parserState.parseTextDecorationStyle('wavy'), TextDecorationStyle.wavy);
+    expect(parserState.parseTextDecorationStyle('solid'), TextDecorationStyle.solid);
+    expect(parserState.parseTextDecorationStyle('dashed'), TextDecorationStyle.dashed);
+    expect(parserState.parseTextDecorationStyle('dotted'), TextDecorationStyle.dotted);
+    expect(parserState.parseTextDecorationStyle('double'), TextDecorationStyle.double);
+    expect(parserState.parseTextDecorationStyle('wavy'), TextDecorationStyle.wavy);
 
     expect(parserState.parseTextDecorationStyle(null), isNull);
-    expect(() => parserState.parseTextDecorationStyle('invalid'),
-        throwsUnsupportedError);
+    expect(() => parserState.parseTextDecorationStyle('invalid'), throwsUnsupportedError);
   });
 
   group('parseStyle', () {
-    test('uses currentColor for stroke color', () {
+    test('uses currentColor for stroke color', () async {
       const Color currentColor = Color(0xFFB0E3BE);
-      final XmlStartElementEvent svg =
-          parseEvents('<svg stroke="currentColor" />').first
-              as XmlStartElementEvent;
+      final XmlStartElementEvent svg = parseEvents('<svg stroke="currentColor" />').first as XmlStartElementEvent;
 
       final TestSvgParserState parserState = TestSvgParserState();
       parserState.attributes = svg.attributes.toAttributeMap();
-      final DrawableStyle svgStyle = parserState.parseStyle(
+      final DrawableStyle svgStyle = await parserState.parseStyle(
         Rect.zero,
         null,
         currentColor: currentColor,
@@ -267,15 +219,13 @@ void main() {
       );
     });
 
-    test('uses currentColor for fill color', () {
+    test('uses currentColor for fill color', () async {
       const Color currentColor = Color(0xFFB0E3BE);
-      final XmlStartElementEvent svg =
-          parseEvents('<svg fill="currentColor" />').first
-              as XmlStartElementEvent;
+      final XmlStartElementEvent svg = parseEvents('<svg fill="currentColor" />').first as XmlStartElementEvent;
 
       final TestSvgParserState parserState = TestSvgParserState();
       parserState.attributes = svg.attributes.toAttributeMap();
-      final DrawableStyle svgStyle = parserState.parseStyle(
+      final DrawableStyle svgStyle = await parserState.parseStyle(
         Rect.zero,
         null,
         currentColor: currentColor,
@@ -288,10 +238,8 @@ void main() {
     });
 
     group('calculates em units based on the font size for', () {
-      test('stroke width', () {
-        final XmlStartElementEvent svg =
-            parseEvents('<circle stroke="green" stroke-width="2em" />').first
-                as XmlStartElementEvent;
+      test('stroke width', () async {
+        final XmlStartElementEvent svg = parseEvents('<circle stroke="green" stroke-width="2em" />').first as XmlStartElementEvent;
 
         const double fontSize = 26.0;
 
@@ -299,7 +247,7 @@ void main() {
           fontSize: fontSize,
         );
         parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = parserState.parseStyle(Rect.zero, null);
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
 
         expect(
           svgStyle.stroke?.strokeWidth,
@@ -307,7 +255,7 @@ void main() {
         );
       });
 
-      test('dash array', () {
+      test('dash array', () async {
         final XmlStartElementEvent svg = parseEvents(
           '<line x2="10" y2="10" stroke="black" stroke-dasharray="0.2em 0.5em 10" />',
         ).first as XmlStartElementEvent;
@@ -318,7 +266,7 @@ void main() {
           fontSize: fontSize,
         );
         parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = parserState.parseStyle(Rect.zero, null);
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
 
         expect(
           <double>[
@@ -334,7 +282,7 @@ void main() {
         );
       });
 
-      test('dash offset', () {
+      test('dash offset', () async {
         final XmlStartElementEvent svg = parseEvents(
           '<line x2="5" y2="30" stroke="black" stroke-dasharray="3 1" stroke-dashoffset="0.15em" />',
         ).first as XmlStartElementEvent;
@@ -345,7 +293,7 @@ void main() {
           fontSize: fontSize,
         );
         parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = parserState.parseStyle(Rect.zero, null);
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
 
         expect(
           svgStyle.dashOffset,
@@ -355,10 +303,8 @@ void main() {
     });
 
     group('calculates ex units based on the x-height for', () {
-      test('stroke width', () {
-        final XmlStartElementEvent svg =
-            parseEvents('<circle stroke="green" stroke-width="2ex" />').first
-                as XmlStartElementEvent;
+      test('stroke width', () async {
+        final XmlStartElementEvent svg = parseEvents('<circle stroke="green" stroke-width="2ex" />').first as XmlStartElementEvent;
 
         const double fontSize = 26.0;
         const double xHeight = 11.0;
@@ -368,7 +314,7 @@ void main() {
           xHeight: xHeight,
         );
         parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = parserState.parseStyle(Rect.zero, null);
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
 
         expect(
           svgStyle.stroke?.strokeWidth,
@@ -376,7 +322,7 @@ void main() {
         );
       });
 
-      test('dash array', () {
+      test('dash array', () async {
         final XmlStartElementEvent svg = parseEvents(
           '<line x2="10" y2="10" stroke="black" stroke-dasharray="0.2ex 0.5ex 10" />',
         ).first as XmlStartElementEvent;
@@ -389,7 +335,7 @@ void main() {
           xHeight: xHeight,
         );
         parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = parserState.parseStyle(Rect.zero, null);
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
 
         expect(
           <double>[
@@ -405,7 +351,7 @@ void main() {
         );
       });
 
-      test('dash offset', () {
+      test('dash offset', () async {
         final XmlStartElementEvent svg = parseEvents(
           '<line x2="5" y2="30" stroke="black" stroke-dasharray="3 1" stroke-dashoffset="0.15ex" />',
         ).first as XmlStartElementEvent;
@@ -418,7 +364,7 @@ void main() {
           xHeight: xHeight,
         );
         parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = parserState.parseStyle(Rect.zero, null);
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
 
         expect(
           svgStyle.dashOffset,

--- a/test/xml_svg_test.dart
+++ b/test/xml_svg_test.dart
@@ -19,20 +19,26 @@ class TestSvgParserState extends SvgParserState {
 
 void main() {
   test('Xlink href tests', () {
-    final XmlStartElementEvent el = parseEvents('<test href="http://localhost" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent el =
+        parseEvents('<test href="http://localhost" />').first
+            as XmlStartElementEvent;
 
-    final XmlStartElementEvent elXlink = parseEvents('<test xmlns:xlink="$kXlinkNamespace" '
-            'xlink:href="http://localhost" />')
-        .first as XmlStartElementEvent;
+    final XmlStartElementEvent elXlink =
+        parseEvents('<test xmlns:xlink="$kXlinkNamespace" '
+                'xlink:href="http://localhost" />')
+            .first as XmlStartElementEvent;
 
-    expect(getHrefAttribute(el.attributes.toAttributeMap()), 'http://localhost');
-    expect(getHrefAttribute(elXlink.attributes.toAttributeMap()), 'http://localhost');
+    expect(
+        getHrefAttribute(el.attributes.toAttributeMap()), 'http://localhost');
+    expect(getHrefAttribute(elXlink.attributes.toAttributeMap()),
+        'http://localhost');
   });
 
   test('Attribute and style tests', () {
-    final XmlStartElementEvent el = parseEvents('<test stroke="#fff" fill="#eee" stroke-dashpattern="1 2" '
-            'style="stroke-opacity:1;fill-opacity:.23" />')
-        .first as XmlStartElementEvent;
+    final XmlStartElementEvent el =
+        parseEvents('<test stroke="#fff" fill="#eee" stroke-dashpattern="1 2" '
+                'style="stroke-opacity:1;fill-opacity:.23" />')
+            .first as XmlStartElementEvent;
     final Map<String, String> attributes = el.attributes.toAttributeMap();
     expect(getAttribute(attributes, 'stroke'), '#fff');
     expect(getAttribute(attributes, 'fill'), '#eee');
@@ -47,32 +53,46 @@ void main() {
 
   // if the parsing logic changes, we can simplify some methods.  for now assert that whitespace in attributes is preserved
   test('Attribute WhiteSpace test', () {
-    final XmlStartElementEvent xd = parseEvents('<test attr="  asdf" attr2="asdf  " attr3="asdf" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent xd =
+        parseEvents('<test attr="  asdf" attr2="asdf  " attr3="asdf" />').first
+            as XmlStartElementEvent;
 
     expect(
       xd.attributes[0].value,
       '  asdf',
-      reason: 'XML Parsing implementation no longer preserves leading whitespace in attributes!',
+      reason:
+          'XML Parsing implementation no longer preserves leading whitespace in attributes!',
     );
     expect(
       xd.attributes[1].value,
       'asdf  ',
-      reason: 'XML Parsing implementation no longer preserves trailing whitespace in attributes!',
+      reason:
+          'XML Parsing implementation no longer preserves trailing whitespace in attributes!',
     );
   });
 
   test('viewBox tests', () {
     const Rect rect = Rect.fromLTWH(0.0, 0.0, 100.0, 100.0);
 
-    final XmlStartElementEvent svgWithViewBox = parseEvents('<svg viewBox="0 0 100 100" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithViewBoxAndWidthHeight = parseEvents('<svg width="50px" height="50px" viewBox="0 0 100 100" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithWidthHeight = parseEvents('<svg width="100" height="100" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithViewBoxMinXMinY = parseEvents('<svg viewBox="42 56 100 100" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent svgWithNoSizeInfo = parseEvents('<svg />').first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithViewBox =
+        parseEvents('<svg viewBox="0 0 100 100" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithViewBoxAndWidthHeight =
+        parseEvents('<svg width="50px" height="50px" viewBox="0 0 100 100" />')
+            .first as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithWidthHeight =
+        parseEvents('<svg width="100" height="100" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithViewBoxMinXMinY =
+        parseEvents('<svg viewBox="42 56 100 100" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent svgWithNoSizeInfo =
+        parseEvents('<svg />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
 
-    Map<String, String> attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
+    Map<String, String> attributes =
+        svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
     expect(parserState.parseViewBox(attributes)!.size, const Size(50, 50));
 
     attributes = svgWithViewBox.attributes.toAttributeMap();
@@ -104,12 +124,21 @@ void main() {
   });
 
   test('TileMode tests', () {
-    final XmlStartElementEvent pad = parseEvents('<linearGradient spreadMethod="pad" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent reflect = parseEvents('<linearGradient spreadMethod="reflect" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent repeat = parseEvents('<linearGradient spreadMethod="repeat" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent invalid = parseEvents('<linearGradient spreadMethod="invalid" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent pad =
+        parseEvents('<linearGradient spreadMethod="pad" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent reflect =
+        parseEvents('<linearGradient spreadMethod="reflect" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent repeat =
+        parseEvents('<linearGradient spreadMethod="repeat" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent invalid =
+        parseEvents('<linearGradient spreadMethod="invalid" />').first
+            as XmlStartElementEvent;
 
-    final XmlStartElementEvent none = parseEvents('<linearGradient />').first as XmlStartElementEvent;
+    final XmlStartElementEvent none =
+        parseEvents('<linearGradient />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
     Map<String, String> attributes = pad.attributes.toAttributeMap();
@@ -129,8 +158,12 @@ void main() {
   });
 
   test('@stroke-dashoffset tests', () {
-    final XmlStartElementEvent abs = parseEvents('<stroke stroke-dashoffset="20" />').first as XmlStartElementEvent;
-    final XmlStartElementEvent pct = parseEvents('<stroke stroke-dashoffset="20%" />').first as XmlStartElementEvent;
+    final XmlStartElementEvent abs =
+        parseEvents('<stroke stroke-dashoffset="20" />').first
+            as XmlStartElementEvent;
+    final XmlStartElementEvent pct =
+        parseEvents('<stroke stroke-dashoffset="20%" />').first
+            as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
     Map<String, String> attributes = abs.attributes.toAttributeMap();
@@ -161,7 +194,8 @@ void main() {
     expect(parserState.parseFontWeight('normal'), FontWeight.normal);
     expect(parserState.parseFontWeight('bold'), FontWeight.bold);
 
-    expect(() => parserState.parseFontWeight('invalid'), throwsUnsupportedError);
+    expect(
+        () => parserState.parseFontWeight('invalid'), throwsUnsupportedError);
   });
 
   test('font-style tests', () {
@@ -177,30 +211,42 @@ void main() {
   test('text-decoration tests', () {
     final TestSvgParserState parserState = TestSvgParserState();
     expect(parserState.parseTextDecoration('none'), TextDecoration.none);
-    expect(parserState.parseTextDecoration('line-through'), TextDecoration.lineThrough);
-    expect(parserState.parseTextDecoration('overline'), TextDecoration.overline);
-    expect(parserState.parseTextDecoration('underline'), TextDecoration.underline);
+    expect(parserState.parseTextDecoration('line-through'),
+        TextDecoration.lineThrough);
+    expect(
+        parserState.parseTextDecoration('overline'), TextDecoration.overline);
+    expect(
+        parserState.parseTextDecoration('underline'), TextDecoration.underline);
 
     expect(parserState.parseTextDecoration(null), isNull);
-    expect(() => parserState.parseTextDecoration('invalid'), throwsUnsupportedError);
+    expect(() => parserState.parseTextDecoration('invalid'),
+        throwsUnsupportedError);
   });
 
   test('text-decoration-style tests', () {
     final TestSvgParserState parserState = TestSvgParserState();
-    expect(parserState.parseTextDecorationStyle('solid'), TextDecorationStyle.solid);
-    expect(parserState.parseTextDecorationStyle('dashed'), TextDecorationStyle.dashed);
-    expect(parserState.parseTextDecorationStyle('dotted'), TextDecorationStyle.dotted);
-    expect(parserState.parseTextDecorationStyle('double'), TextDecorationStyle.double);
-    expect(parserState.parseTextDecorationStyle('wavy'), TextDecorationStyle.wavy);
+    expect(parserState.parseTextDecorationStyle('solid'),
+        TextDecorationStyle.solid);
+    expect(parserState.parseTextDecorationStyle('dashed'),
+        TextDecorationStyle.dashed);
+    expect(parserState.parseTextDecorationStyle('dotted'),
+        TextDecorationStyle.dotted);
+    expect(parserState.parseTextDecorationStyle('double'),
+        TextDecorationStyle.double);
+    expect(
+        parserState.parseTextDecorationStyle('wavy'), TextDecorationStyle.wavy);
 
     expect(parserState.parseTextDecorationStyle(null), isNull);
-    expect(() => parserState.parseTextDecorationStyle('invalid'), throwsUnsupportedError);
+    expect(() => parserState.parseTextDecorationStyle('invalid'),
+        throwsUnsupportedError);
   });
 
   group('parseStyle', () {
     test('uses currentColor for stroke color', () async {
       const Color currentColor = Color(0xFFB0E3BE);
-      final XmlStartElementEvent svg = parseEvents('<svg stroke="currentColor" />').first as XmlStartElementEvent;
+      final XmlStartElementEvent svg =
+          parseEvents('<svg stroke="currentColor" />').first
+              as XmlStartElementEvent;
 
       final TestSvgParserState parserState = TestSvgParserState();
       final Map<String, String> attributes = svg.attributes.toAttributeMap();
@@ -219,7 +265,9 @@ void main() {
 
     test('uses currentColor for fill color', () async {
       const Color currentColor = Color(0xFFB0E3BE);
-      final XmlStartElementEvent svg = parseEvents('<svg fill="currentColor" />').first as XmlStartElementEvent;
+      final XmlStartElementEvent svg =
+          parseEvents('<svg fill="currentColor" />').first
+              as XmlStartElementEvent;
 
       final TestSvgParserState parserState = TestSvgParserState();
       final Map<String, String> attributes = svg.attributes.toAttributeMap();
@@ -238,7 +286,9 @@ void main() {
 
     group('calculates em units based on the font size for', () {
       test('stroke width', () async {
-        final XmlStartElementEvent svg = parseEvents('<circle stroke="green" stroke-width="2em" />').first as XmlStartElementEvent;
+        final XmlStartElementEvent svg =
+            parseEvents('<circle stroke="green" stroke-width="2em" />').first
+                as XmlStartElementEvent;
 
         const double fontSize = 26.0;
 
@@ -246,7 +296,8 @@ void main() {
           fontSize: fontSize,
         );
         final Map<String, String> attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
+        final DrawableStyle svgStyle =
+            await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.stroke?.strokeWidth,
@@ -265,7 +316,8 @@ void main() {
           fontSize: fontSize,
         );
         final Map<String, String> attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
+        final DrawableStyle svgStyle =
+            await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           <double>[
@@ -292,7 +344,8 @@ void main() {
           fontSize: fontSize,
         );
         final Map<String, String> attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
+        final DrawableStyle svgStyle =
+            await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.dashOffset,
@@ -303,7 +356,9 @@ void main() {
 
     group('calculates ex units based on the x-height for', () {
       test('stroke width', () async {
-        final XmlStartElementEvent svg = parseEvents('<circle stroke="green" stroke-width="2ex" />').first as XmlStartElementEvent;
+        final XmlStartElementEvent svg =
+            parseEvents('<circle stroke="green" stroke-width="2ex" />').first
+                as XmlStartElementEvent;
 
         const double fontSize = 26.0;
         const double xHeight = 11.0;
@@ -313,7 +368,8 @@ void main() {
           xHeight: xHeight,
         );
         final Map<String, String> attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
+        final DrawableStyle svgStyle =
+            await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.stroke?.strokeWidth,
@@ -334,7 +390,8 @@ void main() {
           xHeight: xHeight,
         );
         final Map<String, String> attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
+        final DrawableStyle svgStyle =
+            await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           <double>[
@@ -363,7 +420,8 @@ void main() {
           xHeight: xHeight,
         );
         final Map<String, String> attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
+        final DrawableStyle svgStyle =
+            await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.dashOffset,

--- a/test/xml_svg_test.dart
+++ b/test/xml_svg_test.dart
@@ -15,9 +15,6 @@ class TestSvgParserState extends SvgParserState {
           'testKey',
           false,
         );
-
-  @override
-  late Map<String, String> attributes;
 }
 
 void main() {
@@ -75,33 +72,33 @@ void main() {
 
     final TestSvgParserState parserState = TestSvgParserState();
 
-    parserState.attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
-    expect(parserState.parseViewBox()!.size, const Size(50, 50));
+    Map<String, String> attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes)!.size, const Size(50, 50));
 
-    parserState.attributes = svgWithViewBox.attributes.toAttributeMap();
-    expect(parserState.parseViewBox()!.viewBoxRect, rect);
+    attributes = svgWithViewBox.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes)!.viewBoxRect, rect);
 
-    parserState.attributes = svgWithViewBox.attributes.toAttributeMap();
-    expect(parserState.parseViewBox()!.viewBoxOffset, Offset.zero);
+    attributes = svgWithViewBox.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes)!.viewBoxOffset, Offset.zero);
 
-    parserState.attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
-    expect(parserState.parseViewBox()!.viewBoxRect, rect);
+    attributes = svgWithViewBoxAndWidthHeight.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes)!.viewBoxRect, rect);
 
-    parserState.attributes = svgWithWidthHeight.attributes.toAttributeMap();
-    expect(parserState.parseViewBox()!.viewBoxRect, rect);
+    attributes = svgWithWidthHeight.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes)!.viewBoxRect, rect);
 
-    parserState.attributes = svgWithNoSizeInfo.attributes.toAttributeMap();
-    expect(parserState.parseViewBox(nullOk: true), null);
+    attributes = svgWithNoSizeInfo.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes, nullOk: true), null);
 
-    parserState.attributes = svgWithNoSizeInfo.attributes.toAttributeMap();
-    expect(() => parserState.parseViewBox(), throwsStateError);
+    attributes = svgWithNoSizeInfo.attributes.toAttributeMap();
+    expect(() => parserState.parseViewBox(attributes), throwsStateError);
 
-    parserState.attributes = svgWithViewBoxMinXMinY.attributes.toAttributeMap();
-    expect(parserState.parseViewBox()!.viewBoxRect, rect);
+    attributes = svgWithViewBoxMinXMinY.attributes.toAttributeMap();
+    expect(parserState.parseViewBox(attributes)!.viewBoxRect, rect);
 
-    parserState.attributes = svgWithViewBoxMinXMinY.attributes.toAttributeMap();
+    attributes = svgWithViewBoxMinXMinY.attributes.toAttributeMap();
     expect(
-      parserState.parseViewBox()!.viewBoxOffset,
+      parserState.parseViewBox(attributes)!.viewBoxOffset,
       const Offset(-42.0, -56.0),
     );
   });
@@ -115,20 +112,20 @@ void main() {
     final XmlStartElementEvent none = parseEvents('<linearGradient />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
-    parserState.attributes = pad.attributes.toAttributeMap();
-    expect(parserState.parseTileMode(), TileMode.clamp);
+    Map<String, String> attributes = pad.attributes.toAttributeMap();
+    expect(parserState.parseTileMode(attributes), TileMode.clamp);
 
-    parserState.attributes = invalid.attributes.toAttributeMap();
-    expect(parserState.parseTileMode(), TileMode.clamp);
+    attributes = invalid.attributes.toAttributeMap();
+    expect(parserState.parseTileMode(attributes), TileMode.clamp);
 
-    parserState.attributes = none.attributes.toAttributeMap();
-    expect(parserState.parseTileMode(), TileMode.clamp);
+    attributes = none.attributes.toAttributeMap();
+    expect(parserState.parseTileMode(attributes), TileMode.clamp);
 
-    parserState.attributes = reflect.attributes.toAttributeMap();
-    expect(parserState.parseTileMode(), TileMode.mirror);
+    attributes = reflect.attributes.toAttributeMap();
+    expect(parserState.parseTileMode(attributes), TileMode.mirror);
 
-    parserState.attributes = repeat.attributes.toAttributeMap();
-    expect(parserState.parseTileMode(), TileMode.repeated);
+    attributes = repeat.attributes.toAttributeMap();
+    expect(parserState.parseTileMode(attributes), TileMode.repeated);
   });
 
   test('@stroke-dashoffset tests', () {
@@ -136,15 +133,15 @@ void main() {
     final XmlStartElementEvent pct = parseEvents('<stroke stroke-dashoffset="20%" />').first as XmlStartElementEvent;
 
     final TestSvgParserState parserState = TestSvgParserState();
-    parserState.attributes = abs.attributes.toAttributeMap();
+    Map<String, String> attributes = abs.attributes.toAttributeMap();
     expect(
-      parserState.parseDashOffset(),
+      parserState.parseDashOffset(attributes),
       equals(const DashOffset.absolute(20.0)),
     );
 
-    parserState.attributes = pct.attributes.toAttributeMap();
+    attributes = pct.attributes.toAttributeMap();
     expect(
-      parserState.parseDashOffset(),
+      parserState.parseDashOffset(attributes),
       equals(DashOffset.percentage(0.2)),
     );
   });
@@ -206,10 +203,11 @@ void main() {
       final XmlStartElementEvent svg = parseEvents('<svg stroke="currentColor" />').first as XmlStartElementEvent;
 
       final TestSvgParserState parserState = TestSvgParserState();
-      parserState.attributes = svg.attributes.toAttributeMap();
+      final Map<String, String> attributes = svg.attributes.toAttributeMap();
       final DrawableStyle svgStyle = await parserState.parseStyle(
         Rect.zero,
         null,
+        attributes,
         currentColor: currentColor,
       );
 
@@ -224,10 +222,11 @@ void main() {
       final XmlStartElementEvent svg = parseEvents('<svg fill="currentColor" />').first as XmlStartElementEvent;
 
       final TestSvgParserState parserState = TestSvgParserState();
-      parserState.attributes = svg.attributes.toAttributeMap();
+      final Map<String, String> attributes = svg.attributes.toAttributeMap();
       final DrawableStyle svgStyle = await parserState.parseStyle(
         Rect.zero,
         null,
+        attributes,
         currentColor: currentColor,
       );
 
@@ -246,8 +245,8 @@ void main() {
         final TestSvgParserState parserState = TestSvgParserState(
           fontSize: fontSize,
         );
-        parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
+        final Map<String, String> attributes = svg.attributes.toAttributeMap();
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.stroke?.strokeWidth,
@@ -265,8 +264,8 @@ void main() {
         final TestSvgParserState parserState = TestSvgParserState(
           fontSize: fontSize,
         );
-        parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
+        final Map<String, String> attributes = svg.attributes.toAttributeMap();
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           <double>[
@@ -292,8 +291,8 @@ void main() {
         final TestSvgParserState parserState = TestSvgParserState(
           fontSize: fontSize,
         );
-        parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
+        final Map<String, String> attributes = svg.attributes.toAttributeMap();
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.dashOffset,
@@ -313,8 +312,8 @@ void main() {
           fontSize: fontSize,
           xHeight: xHeight,
         );
-        parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
+        final Map<String, String> attributes = svg.attributes.toAttributeMap();
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.stroke?.strokeWidth,
@@ -334,8 +333,8 @@ void main() {
           fontSize: fontSize,
           xHeight: xHeight,
         );
-        parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
+        final Map<String, String> attributes = svg.attributes.toAttributeMap();
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           <double>[
@@ -363,8 +362,8 @@ void main() {
           fontSize: fontSize,
           xHeight: xHeight,
         );
-        parserState.attributes = svg.attributes.toAttributeMap();
-        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null);
+        final Map<String, String> attributes = svg.attributes.toAttributeMap();
+        final DrawableStyle svgStyle = await parserState.parseStyle(Rect.zero, null, attributes);
 
         expect(
           svgStyle.dashOffset,


### PR DESCRIPTION
Fixes #102 
Defs and refs can now be used anywhere, the parsing is now partially async and will await for the def/ref to be defined or throw a warning (like previously) when not found and the full file is processed.
This is a very different approach than #748 which only solves defs and has a lower impact
This is also not (yet) compatible with #754 
I haven't done a benchmark yet, so I don't know the full impact yet, but I've tried to minimise it. Let me know if this is something you expect 😄.
