### PR TITLE
Update pub.dev links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
-homepage: https://github.com/dnfield/flutter_svg
+repository: https://github.com/dnfield/flutter_svg
+issue_tracker: https://github.com/dnfield/flutter_svg/issues
 version: 1.1.4
 
 dependencies:


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).