### PR TITLE
README: Remove `AssetLoader()` from the precompiled asset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:vector_graphics/vector_graphics.dart';
 
 final Widget svg = SvgPicture(
-  AssetLoader(const AssetBytesLoader('assets/foo.svg.vec'))
+  const AssetBytesLoader('assets/foo.svg.vec')
 );
 ```
 


### PR DESCRIPTION
I'm not sure why `AssetLoader()` is included in this sample, but I found that `AssetBytesLoader()` returns the `BytesLoader` that `SvgPicture` expects to receive.