### PR TITLE
Fix faulty cache assertion, bump vg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # CHANGES
 
+## 2.0.3
+
+- Require newer version of vector_graphics.
+- Fix bug in cache that incorrectly fired assert.
+
 ## 2.0.2
 
-- Consume newer version of vector_graphics with multiple fixes around
+- Require newer version of vector_graphics with multiple fixes around
   inheritence, patterns, and currentColor handling.
 
 ## 2.0.1

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -120,7 +120,6 @@ linter:
     - prefer_const_literals_to_create_immutables
     # - prefer_constructors_over_static_methods # not yet tested
     - prefer_contains
-    - prefer_equal_for_default_values
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_locals

--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -87,7 +87,6 @@ class Cache {
       pendingResult.then((ByteData data) {
         _pending.remove(key);
         _add(key, data);
-
         result = data; // in case it was a synchronous future.
       });
     }
@@ -101,7 +100,7 @@ class Cache {
 
   void _add(Object key, ByteData result) {
     if (maximumSize > 0) {
-      assert(_cache.length < maximumSize);
+      assert(_cache.containsKey(key) || _cache.length < maximumSize);
       _cache[key] = result;
     }
     assert(_cache.length <= maximumSize);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,14 +2,14 @@ name: flutter_svg
 description: An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
 repository: https://github.com/dnfield/flutter_svg
 issue_tracker: https://github.com/dnfield/flutter_svg/issues
-version: 2.0.2
+version: 2.0.3
 
 dependencies:
   flutter:
     sdk: flutter
-  vector_graphics: ^1.1.0
-  vector_graphics_codec: ^1.1.0
-  vector_graphics_compiler: ^1.1.0
+  vector_graphics: ^1.1.3
+  vector_graphics_codec: ^1.1.3
+  vector_graphics_compiler: ^1.1.3
 
 dev_dependencies:
   flutter_test:

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_svg/src/cache.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -76,5 +77,33 @@ void main() {
     expect(cache.evict(1), true);
     expect(cache.evict(2), false);
     expect(cache.evict(3), true);
+  });
+
+  test('Adding beyond max with synchronous futures', () async {
+    final Cache cache = Cache();
+    cache.maximumSize = 2;
+    final Future<ByteData> completerA =
+        SynchronousFuture<ByteData>(ByteData(1));
+    final Future<ByteData> completerB =
+        SynchronousFuture<ByteData>(ByteData(2));
+    final Future<ByteData> completerC =
+        SynchronousFuture<ByteData>(ByteData(3));
+
+    expect(cache.count, 0);
+
+    cache.putIfAbsent(1, () => completerA);
+    expect(cache.count, 1);
+
+    cache.putIfAbsent(2, () => completerB);
+    expect(cache.count, 2);
+
+    cache.putIfAbsent(2, () => completerB);
+    expect(cache.count, 2);
+
+    cache.putIfAbsent(3, () => completerC);
+    expect(cache.count, 2);
+
+    cache.putIfAbsent(2, () => completerB);
+    expect(cache.count, 2);
   });
 }

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_svg/src/cache.dart';


### PR DESCRIPTION
The assertion would fire in the case where a synchronous future was added that was already contained in the cache when the cache was at max capacity.

This broadens the assertion a bit and adds a test. Also bumps VG to newest version.

Fixes #863 