### PR TITLE
Adds DefaultSvgTheme

### DIFF
--- a/packages/flutter_svg/CHANGELOG.md
+++ b/packages/flutter_svg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## 2.0.8
+
+- Adds back `DefaultSvgTheme`.
+
 ## 2.0.7
 
 - Fix broken `matchTextDirection`.

--- a/packages/flutter_svg/lib/src/default_theme.dart
+++ b/packages/flutter_svg/lib/src/default_theme.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/widgets.dart';
+
+import 'loaders.dart';
+
+/// The SVG theme to apply to descendant [SvgPicture] widgets
+/// which don't have explicit theme values.
+class DefaultSvgTheme extends InheritedTheme {
+  /// Creates a default SVG theme for the given subtree
+  /// using the provided [theme].
+  const DefaultSvgTheme({
+    Key? key,
+    required Widget child,
+    required this.theme,
+  }) : super(key: key, child: child);
+
+  /// The SVG theme to apply.
+  final SvgTheme theme;
+
+  /// The closest instance of this class that encloses the given context.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// DefaultSvgTheme theme = DefaultSvgTheme.of(context);
+  /// ```
+  static DefaultSvgTheme? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DefaultSvgTheme>();
+  }
+
+  @override
+  bool updateShouldNotify(DefaultSvgTheme oldWidget) {
+    return theme != oldWidget.theme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return DefaultSvgTheme(
+      theme: theme,
+      child: child,
+    );
+  }
+}

--- a/packages/flutter_svg/lib/svg.dart
+++ b/packages/flutter_svg/lib/svg.dart
@@ -12,6 +12,7 @@ export 'package:vector_graphics/vector_graphics.dart'
     show BytesLoader, vg, VectorGraphicUtilities, PictureInfo;
 
 export 'src/cache.dart';
+export 'src/default_theme.dart';
 export 'src/loaders.dart';
 
 /// Instance for [Svg]'s utility methods, which can produce a [DrawableRoot]
@@ -84,7 +85,6 @@ class SvgPicture extends StatelessWidget {
     this.semanticsLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
-    this.theme = const SvgTheme(),
     @deprecated bool cacheColorFilter = false,
   }) : super(key: key);
 
@@ -179,7 +179,7 @@ class SvgPicture extends StatelessWidget {
     this.semanticsLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
-    this.theme = const SvgTheme(),
+    SvgTheme? theme,
     ui.ColorFilter? colorFilter,
     @deprecated ui.Color? color,
     @deprecated ui.BlendMode colorBlendMode = ui.BlendMode.srcIn,
@@ -243,7 +243,7 @@ class SvgPicture extends StatelessWidget {
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
     @deprecated bool cacheColorFilter = false,
-    this.theme = const SvgTheme(),
+    SvgTheme? theme,
   })  : bytesLoader = SvgNetworkLoader(url, headers: headers, theme: theme),
         colorFilter = colorFilter ?? _getColorFilter(color, colorBlendMode),
         super(key: key);
@@ -294,7 +294,7 @@ class SvgPicture extends StatelessWidget {
     this.semanticsLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
-    this.theme = const SvgTheme(),
+    SvgTheme? theme,
     @deprecated bool cacheColorFilter = false,
   })  : bytesLoader = SvgFileLoader(file, theme: theme),
         colorFilter = colorFilter ?? _getColorFilter(color, colorBlendMode),
@@ -343,7 +343,7 @@ class SvgPicture extends StatelessWidget {
     this.semanticsLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
-    this.theme = const SvgTheme(),
+    SvgTheme? theme,
     @deprecated bool cacheColorFilter = false,
   })  : bytesLoader = SvgBytesLoader(bytes, theme: theme),
         colorFilter = colorFilter ?? _getColorFilter(color, colorBlendMode),
@@ -392,7 +392,7 @@ class SvgPicture extends StatelessWidget {
     this.semanticsLabel,
     this.excludeFromSemantics = false,
     this.clipBehavior = Clip.hardEdge,
-    this.theme = const SvgTheme(),
+    SvgTheme? theme,
     @deprecated bool cacheColorFilter = false,
   })  : bytesLoader = SvgStringLoader(string, theme: theme),
         colorFilter = colorFilter ?? _getColorFilter(color, colorBlendMode),
@@ -478,9 +478,6 @@ class SvgPicture extends StatelessWidget {
 
   /// The color filter, if any, to apply to this widget.
   final ColorFilter? colorFilter;
-
-  /// The theme used when parsing SVG elements.
-  final SvgTheme theme;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter_svg/test/default_theme_test.dart
+++ b/packages/flutter_svg/test/default_theme_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DefaultSvgTheme', () {
+    testWidgets('changes propagate to SvgPicture', (WidgetTester tester) async {
+      const SvgTheme svgTheme = SvgTheme(
+        currentColor: Color(0xFF733821),
+        fontSize: 14.0,
+        xHeight: 6.0,
+      );
+
+      final SvgPicture svgPictureWidget = SvgPicture.string('''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10em" height="10" fill="currentColor" />
+</svg>''');
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: svgTheme,
+        child: svgPictureWidget,
+      ));
+
+      SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      BuildContext context = tester.element(find.byType(SvgPicture));
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader).getTheme(context),
+        equals(svgTheme),
+      );
+
+      const SvgTheme anotherSvgTheme = SvgTheme(
+        currentColor: Color(0xFF05290E),
+        fontSize: 12.0,
+        xHeight: 7.0,
+      );
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: anotherSvgTheme,
+        child: svgPictureWidget,
+      ));
+      context = tester.element(find.byType(SvgPicture));
+
+      svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader).getTheme(context),
+        equals(anotherSvgTheme),
+      );
+    });
+
+    testWidgets(
+        'currentColor from the widget\'s theme takes precedence over '
+        'the theme from DefaultSvgTheme', (WidgetTester tester) async {
+      const SvgTheme svgTheme = SvgTheme(
+        currentColor: Color(0xFF733821),
+        fontSize: 14.0,
+      );
+
+      final SvgPicture svgPictureWidget = SvgPicture.string(
+        '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10" height="10" fill="currentColor" />
+</svg>''',
+        theme: const SvgTheme(
+          currentColor: Color(0xFF05290E),
+          fontSize: 14.0,
+        ),
+      );
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: svgTheme,
+        child: svgPictureWidget,
+      ));
+      final BuildContext context = tester.element(find.byType(SvgPicture));
+      final SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader)
+            .getTheme(context)
+            .currentColor,
+        equals(const Color(0xFF05290E)),
+      );
+    });
+
+    testWidgets(
+        'fontSize from the widget\'s theme takes precedence over '
+        'the theme from DefaultSvgTheme', (WidgetTester tester) async {
+      const SvgTheme svgTheme = SvgTheme(
+        fontSize: 14.0,
+      );
+
+      final SvgPicture svgPictureWidget = SvgPicture.string(
+        '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10em" height="10em" />
+</svg>''',
+        theme: const SvgTheme(
+          fontSize: 12.0,
+        ),
+      );
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: svgTheme,
+        child: svgPictureWidget,
+      ));
+
+      final SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      final BuildContext context = tester.element(find.byType(SvgPicture));
+
+      expect(svgPicture, isNotNull);
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader).getTheme(context).fontSize,
+        equals(12.0),
+      );
+    });
+
+    testWidgets(
+        'fontSize defaults to 14 '
+        'if no widget\'s theme, DefaultSvgTheme or DefaultTextStyle is provided',
+        (WidgetTester tester) async {
+      final SvgPicture svgPictureWidget = SvgPicture.string(
+        '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10em" height="10em" />
+</svg>''',
+      );
+
+      await tester.pumpWidget(svgPictureWidget);
+
+      final SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      final BuildContext context = tester.element(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader).getTheme(context).fontSize,
+        equals(14.0),
+      );
+    });
+
+    testWidgets(
+        'xHeight from the widget\'s theme takes precedence over '
+        'the theme from DefaultSvgTheme', (WidgetTester tester) async {
+      const SvgTheme svgTheme = SvgTheme(
+        fontSize: 14.0,
+        xHeight: 6.5,
+      );
+
+      final SvgPicture svgPictureWidget = SvgPicture.string(
+        '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10ex" height="10ex" />
+</svg>''',
+        theme: const SvgTheme(
+          fontSize: 12.0,
+          xHeight: 7.0,
+        ),
+      );
+
+      await tester.pumpWidget(DefaultSvgTheme(
+        theme: svgTheme,
+        child: svgPictureWidget,
+      ));
+
+      final SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      final BuildContext context = tester.element(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader).getTheme(context).xHeight,
+        equals(7.0),
+      );
+    });
+
+    testWidgets(
+        'xHeight defaults to the font size divided by 2 (7.0) '
+        'if no widget\'s theme or DefaultSvgTheme is provided',
+        (WidgetTester tester) async {
+      final SvgPicture svgPictureWidget = SvgPicture.string(
+        '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="10ex" height="10ex" />
+</svg>''',
+      );
+
+      await tester.pumpWidget(svgPictureWidget);
+
+      final SvgPicture svgPicture = tester.firstWidget(find.byType(SvgPicture));
+      final BuildContext context = tester.element(find.byType(SvgPicture));
+      expect(svgPicture, isNotNull);
+      expect(
+        (svgPicture.bytesLoader as SvgStringLoader).getTheme(context).xHeight,
+        equals(7.0),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes https://github.com/dnfield/flutter_svg/issues/953

Some notes/questions:
1. In this PR, I basically copied over the `DefaultSvgTheme` from v1.1.6
2. For the tests, I also copied them except for [this one test](https://github.com/dnfield/flutter_svg/blob/3753ff989c1f7c6ef4781d0772b4a3fe0dde9345/test/default_theme_test.dart#L114-L138) about the `fontSize` being based on the `DefaultTextStyle` because of [this comment](https://github.com/dnfield/flutter_svg/blob/d7b5c23a79dcb5425548879bdb79a5e7f5097ce5/packages/flutter_svg/lib/src/loaders.dart#L20-L26)
3. I noticed that the `SvgTheme` in `flutter_svg/lib/src/loaders.dart` seems to duplicate the one from `vector_graphics_compiler`. Shouldn't we use only the one from `vector_graphics_compiler`?