### PR TITLE
Update flutter_svg README with an example to scale images

### DIFF
--- a/packages/flutter_svg/README.md
+++ b/packages/flutter_svg/README.md
@@ -69,6 +69,15 @@ canvas.drawPicture(pictureInfo.picture);
 // Or convert the picture to an image:
 final ui.Image image = pictureInfo.picture.toImage(...);
 
+// Or convert the picture to a scaled image:
+const double targetWidth = 512;
+const double targetHeight = 512;
+final ui.PictureRecorder pictureRecorder = ui.PictureRecorder();
+final ui.Canvas canvas = Canvas(pictureRecorder, Rect.fromPoints(Offset.zero, Offset(targetWidth, targetHeight)));
+canvas.scale(targetWidth / pictureInfo.size.width, targetHeight / pictureInfo.size.height);
+canvas.drawPicture(picture);
+final ui.Image scaledImage = await pictureRecorder.endRecording().toImage(targetWidth.ceil(), targetHeight.ceil());
+
 pictureInfo.picture.dispose();
 ```
 

--- a/packages/flutter_svg/README.md
+++ b/packages/flutter_svg/README.md
@@ -75,7 +75,7 @@ const double targetHeight = 512;
 final ui.PictureRecorder pictureRecorder = ui.PictureRecorder();
 final ui.Canvas canvas = Canvas(pictureRecorder, Rect.fromPoints(Offset.zero, Offset(targetWidth, targetHeight)));
 canvas.scale(targetWidth / pictureInfo.size.width, targetHeight / pictureInfo.size.height);
-canvas.drawPicture(picture);
+canvas.drawPicture(pictureInfo.picture);
 final ui.Image scaledImage = await pictureRecorder.endRecording().toImage(targetWidth.ceil(), targetHeight.ceil());
 
 pictureInfo.picture.dispose();


### PR DESCRIPTION
Update the flutter_svg README file to add an example of how we can scale an SVG image into a ui.Image.

This might address the following issues:

* https://github.com/dnfield/flutter_svg/issues/858
* https://github.com/yang-f/flutter_svg_provider/issues/47