### PR TITLE
Avoid expanding the parameter type of operator==

### DIFF
--- a/packages/flutter_svg/lib/src/loaders.dart
+++ b/packages/flutter_svg/lib/src/loaders.dart
@@ -54,7 +54,7 @@ class SvgTheme {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) {
       return false;
     }


### PR DESCRIPTION
Object.operator== takes an `Object`, and no Dart runtime passes a `null` value to an `==` implementation. SvgTheme's implementation should not have an expanded parameter type of `dynamic`.

See https://github.com/flutter/flutter/issues/117838 for the overarching issue for Flutter.