### PR TITLE
fix(cache): remove entry from _pending in case of exception

### DIFF
--- a/packages/flutter_svg/lib/src/cache.dart
+++ b/packages/flutter_svg/lib/src/cache.dart
@@ -85,6 +85,8 @@ class Cache {
         _pending.remove(key);
         _add(key, data);
         result = data; // in case it was a synchronous future.
+      }).catchError((Object e, _) {
+        _pending.remove(key);
       });
     }
     if (result != null) {

--- a/packages/flutter_svg/test/cache_test.dart
+++ b/packages/flutter_svg/test/cache_test.dart
@@ -133,4 +133,19 @@ void main() {
     await null;
     expect(cache.count, 2);
   });
+
+  test('Exception thrown during loader execution is handled', () async {
+    final Cache cache = Cache();
+
+    Future<ByteData> futureThatThrows() async =>
+        Future<ByteData>.error(Exception('Exception inside future'));
+    await expectLater(
+      cache.putIfAbsent(1, () => futureThatThrows()),
+      throwsA(anything),
+    );
+
+    Future<ByteData> futureThatDoesntThrow() async => ByteData(1);
+    // Doesn't throw an error
+    await cache.putIfAbsent(1, () => futureThatDoesntThrow());
+  });
 }


### PR DESCRIPTION
### Issue
If an exception is thrown during `loader` execution - future with error result will be stuck in the `_pending` map and it will be returned every time `putIfAbsent` is called. There is no way to evict it either, since `evict` method only affects `_cache` map.
The exception in loader may be thrown in case of network error when `SvgNetworkLoader` is used.
### Change
This change adds a `catchError` handler to remove future from the `_pending` map in case of failure. Also a regression test is added that will fail without this fix. 